### PR TITLE
Add homebrew and golangci-lint to image/template

### DIFF
--- a/ddev-user/template.tf
+++ b/ddev-user/template.tf
@@ -153,7 +153,7 @@ resource "docker_image" "workspace_image" {
 variable "node_version" {
   description = "Node.js version to install"
   type        = string
-  default     = "20"
+  default     = "24"
 }
 
 variable "cpu" {
@@ -394,10 +394,9 @@ resource "coder_agent" "main" {
     fi
     export CODER_WORKSPACE_NAME
 
-    # Ensure ddev is in PATH
-    export PATH="$HOME/.ddev/bin:$PATH"
-    if ! echo "$PATH" | grep -q "$HOME/.ddev/bin"; then
-      echo 'export PATH="$HOME/.ddev/bin:$PATH"' >> ~/.bashrc
+    # Ensure linuxbrew/homebrew is in PATH
+    if ! echo "$PATH" | grep -q "/home/linuxbrew/.linuxbrew/bin"; then
+      echo 'export PATH="$PATH:/home/linuxbrew/.linuxbrew/bin"' >> ~/.bashrc
     fi
     
     # Remove any old welcome message entries from .bashrc (if they exist)

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -159,7 +159,11 @@ RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor -o /etc/apt/keyr
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ddev && \
   rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /home/linuxbrew/.linuxbrew && chown -R coder:coder /home/linuxbrew/
+
 USER coder
-# Verify installation
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+RUN /home/linuxbrew/.linuxbrew/bin/brew install golangci-lint
+
 RUN ddev --version && \
   docker --version


### PR DESCRIPTION
This is my first little round of editing template and Dockerfile. 

After pushing, the new docker image had to be explicitly downloaded with `docker pull` because I didn't change the VERSION.