### PR TITLE
feat: add git branch to bash prompt and improve VS Code defaults

### DIFF
--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -313,7 +313,15 @@ resource "coder_agent" "main" {
     # Copy files from /home/coder-files to /home/coder
     # The volume mount at /home/coder overrides image contents, but /home/coder-files is outside the mount
     echo "Copying files from /home/coder-files to ~/..."
-    if [ ! -d /home/coder-files ]; then
+    if [ -d /home/coder-files ]; then
+      if [ -d /home/coder-files/.vscode ]; then
+        mkdir -p ~/.vscode
+        if [ -f /home/coder-files/.vscode/settings.json ]; then
+          cp /home/coder-files/.vscode/settings.json ~/.vscode/settings.json
+          chown coder:coder ~/.vscode/settings.json 2>/dev/null || true
+        fi
+      fi
+    else
       echo "Warning: /home/coder-files not found in image"
     fi
 
@@ -338,6 +346,18 @@ resource "coder_agent" "main" {
     
     # FIX: Remove stale GIT_SSH_COMMAND from .bashrc if present (from older versions)
     sed -i '/export GIT_SSH_COMMAND=/d' ~/.bashrc || true
+
+    # Add git branch to bash prompt
+    if ! grep -q "git_prompt()" ~/.bashrc; then
+      echo '' >> ~/.bashrc
+      echo '# Git branch in prompt' >> ~/.bashrc
+      echo 'git_prompt() {' >> ~/.bashrc
+      echo '    local branch' >> ~/.bashrc
+      echo '    branch="$(git symbolic-ref HEAD 2>/dev/null | cut -d/ -f3-)"' >> ~/.bashrc
+      echo '    [ -n "$branch" ] && echo " ($branch)"' >> ~/.bashrc
+      echo '}' >> ~/.bashrc
+      echo 'PS1='\''\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(git_prompt)\$ '\''' >> ~/.bashrc
+    fi
 
     # Node.js, TypeScript, and DDEV are now pre-installed in the Docker image (v3.0.30+)
 

--- a/image/scripts/.vscode/settings.json
+++ b/image/scripts/.vscode/settings.json
@@ -5,5 +5,13 @@
       "path": "/bin/bash",
       "args": ["--login"]
     }
-  }
+  },
+  "explorer.openEditors.visible": 0,
+  "explorer.compactFolders": false,
+  "explorer.confirmDragAndDrop": false,
+  "workbench.startupEditor": "none",
+  "workbench.editor.tabSizing": "shrink",
+  "editor.cursorSurroundingLines": 6,
+  "diffEditor.ignoreTrimWhitespace": false,
+  "redhat.telemetry.enabled": false
 }

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -289,6 +289,18 @@ resource "coder_agent" "main" {
     # FIX: Remove stale GIT_SSH_COMMAND from .bashrc if present (from older versions)
     sed -i '/export GIT_SSH_COMMAND=/d' ~/.bashrc || true
 
+    # Add git branch to bash prompt
+    if ! grep -q "git_prompt()" ~/.bashrc; then
+      echo '' >> ~/.bashrc
+      echo '# Git branch in prompt' >> ~/.bashrc
+      echo 'git_prompt() {' >> ~/.bashrc
+      echo '    local branch' >> ~/.bashrc
+      echo '    branch="$(git symbolic-ref HEAD 2>/dev/null | cut -d/ -f3-)"' >> ~/.bashrc
+      echo '    [ -n "$branch" ] && echo " ($branch)"' >> ~/.bashrc
+      echo '}' >> ~/.bashrc
+      echo 'PS1='\''\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(git_prompt)\$ '\''' >> ~/.bashrc
+    fi
+
     # Node.js, TypeScript, and DDEV are now pre-installed in the Docker image (v3.0.30+)
 
 


### PR DESCRIPTION
## Summary

@rpkoller suggestions:

- Add `git_prompt()` to `.bashrc` via startup scripts in both templates — terminal prompt shows current branch as `coder@host:~/path (branch)$`
- Add 8 useful VS Code settings to `image/scripts/.vscode/settings.json` based on suggestions from @rpkoller: hide open-editors pane, disable compact folders, no drag-drop confirm, no startup editor tab, shrink tabs, cursor surrounding lines, show whitespace in diffs, disable RedHat telemetry
- Fix drupal-core startup script to copy `.vscode/settings.json` from image (was missing, unlike user-defined-web)

## Test plan

- [ ] Start a new workspace and open the terminal — prompt should show branch name when inside a git repo
- [ ] Navigate outside a git repo — prompt should show plain `user@host:~/path$`
- [ ] Restart an existing workspace — git prompt should be added to `.bashrc` (idempotent, no duplicates)
- [ ] Verify VS Code opens without a welcome/startup tab
- [ ] Verify explorer has no "OPEN EDITORS" section and shows full folder paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)