### PR TITLE
feat: add Drupal Site app with second healthcheck indicator

### DIFF
--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1339,10 +1339,33 @@ resource "coder_app" "ddev-web" {
   subdomain    = true
   share        = "owner"
 
+  # Healthy when ddev is running and the web server responds (any 2xx/3xx).
+  # Lights up as soon as `ddev start` completes, before Drupal is installed.
   healthcheck {
     url       = "http://localhost:80"
     interval  = 10
     threshold = 30
+  }
+}
+
+resource "coder_app" "drupal-site" {
+  agent_id     = coder_agent.main.id
+  slug         = "drupal-site"
+  display_name = "Drupal Site"
+  order        = 2
+  url          = "http://localhost:80"
+  icon         = "https://api.iconify.design/heroicons:check-circle.svg?color=white"
+  subdomain    = true
+  share        = "owner"
+
+  # Healthy only when Drupal returns 200. /user/login returns 500 when the
+  # database isn't set up (before drush si) and 200 when Drupal is fully
+  # installed — giving a "site is actually working" indicator distinct from
+  # "web server is up".
+  healthcheck {
+    url       = "http://localhost:80/user/login"
+    interval  = 10
+    threshold = 3
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a second app icon **Drupal Site** (white check-circle) alongside the existing **DDEV Web** icon, giving two distinct health indicators with different semantics.

## How Coder app healthchecks work

Each [`coder_app`](https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app) resource can have a `healthcheck` block that polls a URL on a configurable interval. The app icon appears **dim** when unhealthy and **bright** when healthy.

**What counts as healthy:** any HTTP response that is not a connection failure and not 5xx. This means 2xx, 3xx, and 4xx all pass. There is no way to require specifically 200, check response body content, or apply any custom logic — status code only.

**Key limitation:** the health indicator is only visible in the individual workspace detail view. The main workspaces list shows only the agent status (Running/Stopped), not per-app health.

Docs: https://registry.terraform.io/providers/coder/coder/latest/docs/resources/app

## The two indicators

| App | Healthcheck URL | Lights up when |
|-----|----------------|----------------|
| DDEV Web | `http://localhost:80` | `ddev start` completes — nginx responds with anything |
| Drupal Site ✓ | `http://localhost:80/user/login` | Drupal is installed — returns non-5xx (typically 200) |

**Why `/user/login`:** before `drush si` completes, Drupal returns 500 (no database). After install it returns 200. This makes the Drupal Site icon dim through the entire setup process and bright only once the site is serving.

## Known limitations

- **sql-drop → redirect:** after `ddev drush sql-drop -y`, Drupal redirects `/user/login` → `/install.php` (302). Coder treats 302 as healthy, so the icon stays bright. A custom `health.php` that tests DB connectivity directly would be needed to catch this.
- **4xx responses pass:** removing `index.php` gives 403 — icon stays bright.
- **PHP errors may return 200:** in DDEV's dev mode (`display_errors=On`), PHP parse errors can return 200 with error text in the body rather than 500.

The icon is a best-effort indicator, not a guarantee of a fully functioning site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)