### PR TITLE
feat: Add GitHub Pull Request extension to workspace template

### DIFF
--- a/docs/user/using-workspaces.md
+++ b/docs/user/using-workspaces.md
@@ -131,6 +131,7 @@ All workspaces come with these extensions automatically installed at workspace s
 | **Code Spell Checker** (`streetsidesoftware.code-spell-checker`) | Spell checking in code and comments |
 | **Stylelint** (`stylelint.vscode-stylelint`) | CSS/SCSS linting |
 | **PHP Sniffer & Beautifier** (`valeryanm.vscode-phpsab`) | PHPCS/PHPCBF integration |
+| **GitHub Pull Requests** (`GitHub.vscode-pull-request-github`) | Pull request and issue provider for GitHub |
 | **DDEV Manager** (`biati.ddev-manager`) | DDEV control panel: start/stop/Xdebug toggle/etc. |
 
 ### Installing Additional Extensions

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -491,6 +491,7 @@ module "vscode-web" {
     "streetsidesoftware.code-spell-checker",
     "stylelint.vscode-stylelint",
     "valeryanm.vscode-phpsab",
+    "GitHub.vscode-pull-request-github",
     "biati.ddev-manager",
   ]
 }


### PR DESCRIPTION
## The Issue
No GitHub Pull Request extension was included in the workspace setup.

## How This PR Solves The Issue
This update adds the GitHub Pull Requests extension to the workspace documentation and the user-defined web template.

Coder uses GitHub for authentication so it make sense to include a helper extension for GitHub.

## Manual Testing Instructions
Verify that the GitHub Pull Requests extension is listed in the workspace documentation and the template file.

## Automated Testing Overview
No automated tests are needed for this change.

## Related Issue Link(s)

## Release/Deployment Notes
No additional deployment steps are required.

