### PR TITLE
feat: add ngrok, cloudflared, telnet, netcat, and standard networking tools, fixes #46

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -11,25 +11,35 @@ RUN apt-get update && \
   build-essential \
   ca-certificates \
   curl \
+  default-mysql-client \
   direnv \
+  dnsutils \
   file \
   git \
   gnupg \
+  htop \
   httpie \
   inetutils-ping \
   less \
   locales \
   lsb-release \
+  lsof \
   make \
   nano \
+  net-tools \
+  netcat-openbsd \
   openssh-client \
   passwd \
+  postgresql-client \
   rsync \
   software-properties-common \
   sudo \
+  telnet \
+  traceroute \
   unzip \
   vim \
-  wget && \
+  wget \
+  zip && \
   # Generate locale
   locale-gen en_US.UTF-8 && \
   rm -rf /var/lib/apt/lists/* && \
@@ -115,6 +125,27 @@ RUN mkdir -p /etc/apt/keyrings && \
     > /etc/apt/sources.list.d/github-cli.list && \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gh && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install ngrok
+# https://ngrok.com/download/linux
+RUN curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
+    -o /etc/apt/keyrings/ngrok.asc && \
+  echo "deb [signed-by=/etc/apt/keyrings/ngrok.asc] https://ngrok-agent.s3.amazonaws.com buster main" \
+    > /etc/apt/sources.list.d/ngrok.list && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ngrok && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install cloudflared
+# https://pkg.cloudflare.com/
+RUN mkdir -p /usr/share/keyrings && \
+  curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg \
+    -o /usr/share/keyrings/cloudflare-main.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared noble main" \
+    > /etc/apt/sources.list.d/cloudflared.list && \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cloudflared && \
   rm -rf /var/lib/apt/lists/*
 
 # Install DDEV using official package installation method


### PR DESCRIPTION
## Summary

Implements #46 and adds additional standard packages to the workspace image.

**From issue #46:**
- `ngrok` — via official apt repo (`ngrok-agent.s3.amazonaws.com`)
- `cloudflared` — via Cloudflare apt repo (`pkg.cloudflare.com`)

**Also added:**
- `telnet` — standard telnet client
- `netcat-openbsd` — `nc` command
- `dnsutils` — `dig`, `nslookup` for DNS debugging
- `net-tools` — `netstat`, `ifconfig`
- `lsof` — list open files/ports
- `htop` — interactive process monitor
- `traceroute` — network path tracing
- `zip` — was missing (only `unzip` was present)
- `default-mysql-client` — `mysql` CLI for DDEV MySQL/MariaDB databases
- `postgresql-client` — `psql` CLI for DDEV PostgreSQL databases

## Test plan

- [ ] Build image with `make build` and verify it completes without errors
- [ ] Start a workspace and confirm `ngrok version`, `cloudflared version` work
- [ ] Confirm `nc`, `telnet`, `dig`, `netstat`, `lsof`, `htop`, `traceroute`, `zip`, `mysql`, `psql` are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)