### PR TITLE
fix: use stable CDN URL for Mailpit icon, fixes #47

### DIFF
--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1426,7 +1426,7 @@ resource "coder_app" "mailpit" {
   display_name = "Mailpit"
   order        = 3
   url          = "http://localhost:8025"
-  icon         = "https://raw.githubusercontent.com/axllent/mailpit/develop/server/ui/public/favicon.svg"
+  icon         = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/mailpit.svg"
   subdomain    = true
   share        = "owner"
 

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -387,7 +387,7 @@ resource "coder_app" "mailpit" {
   slug         = "mailpit"
   display_name = "Mailpit"
   url          = "http://localhost:8025"
-  icon         = "/icon/mailhog.svg"
+  icon         = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/mailpit.svg"
   subdomain    = true
   share        = "owner"
 


### PR DESCRIPTION
## Summary

- **freeform**: replaced `/icon/mailhog.svg` (wrong app — MailHog is not DDEV's mail tool) with correct Mailpit icon
- **drupal-core**: replaced GitHub raw URL that was returning 404 with a stable CDN URL
- Both templates now use `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/mailpit.svg`

## Test plan

- [x] `make push-template-freeform` succeeds (previously failed with `value too long for type character varying(256)`)
- [ ] Mailpit icon renders correctly in workspace list for both freeform and drupal-core templates

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)