### PR TITLE
Filter hidden branches from drupal issue picker and pre-select most recent, fixes #37

### DIFF
--- a/docs/drupal-issue.html
+++ b/docs/drupal-issue.html
@@ -582,18 +582,49 @@
           }
         } catch (_) { /* title/version stay as fallback */ }
 
+        // Step 2.5: Try to get visible branches from Drupal.org issue page.
+        // The drupalorgBranchData settings key lists only non-hidden branches (those with MRs).
+        // Hidden branches exist in GitLab but are suppressed in the Drupal.org UI.
+        let visibleBranchNames = null;
+        try {
+          const pageResp = await fetch('https://www.drupal.org/project/drupal/issues/' + nid);
+          if (pageResp.ok) {
+            const html = await pageResp.text();
+            const settingsMatch = html.match(/<script[^>]+data-drupal-selector="drupal-settings-json"[^>]*>([\s\S]*?)<\/script>/);
+            if (settingsMatch) {
+              const settings = JSON.parse(settingsMatch[1]);
+              if (settings.drupalorgBranchData && Object.keys(settings.drupalorgBranchData).length > 0) {
+                visibleBranchNames = new Set(Object.keys(settings.drupalorgBranchData));
+              }
+            }
+          }
+        } catch (_) { /* CORS or parse error — fall through to prefix filter */ }
+
+        // Filter to visible branches only:
+        // - Primary: use Drupal.org's drupalorgBranchData (excludes hidden branches)
+        // - Fallback: branches matching the issue number prefix (excludes inherited upstream branches)
+        const issueBranches = visibleBranchNames
+          ? branches.filter(b => visibleBranchNames.has(b.name))
+          : branches.filter(b => b.name.startsWith(nid + '-'));
+
+        // Use filtered list, falling back to all branches only if filtering yields nothing
+        const displayBranches = issueBranches.length > 0 ? issueBranches : branches;
+
         // Populate branch selector
         const branchSelect = document.getElementById('branch-select');
         branchSelect.innerHTML = '';
-        branches.forEach(b => {
+        displayBranches.forEach(b => {
           const opt = document.createElement('option');
           opt.value = b.name;
           opt.textContent = b.name;
           branchSelect.appendChild(opt);
         });
 
-        // Pre-select branch that starts with the issue number
-        const preferred = branches.find(b => b.name.startsWith(nid + '-'));
+        // Pre-select the most recently committed branch (most actively worked on)
+        const preferred = displayBranches.reduce((best, b) => {
+          if (!best) return b;
+          return b.commit.committed_date > best.commit.committed_date ? b : best;
+        }, null);
         if (preferred) branchSelect.value = preferred.name;
 
         // Set issue title with clickable link


### PR DESCRIPTION
## Summary

- fixes #37 
- Fetches `drupalorgBranchData` from the Drupal.org issue page to identify visible branches — hidden branches are suppressed in that data and excluded from the dropdown
- Falls back to filtering by issue-number prefix (e.g. `3568144-*`) if CORS blocks the page fetch, which at minimum eliminates the 40+ inherited upstream Drupal branches
- Pre-selects the branch with the most recent commit rather than the first alphabetical match, so the most actively worked-on branch is the default

Fixes #37

## Test plan

- [ ] Load an issue with known hidden branches and confirm the hidden branch does not appear in the dropdown
- [ ] Confirm the most recently committed branch is pre-selected when multiple branches exist
- [ ] Confirm fallback still works (loads issue branches) if the drupal.org page fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)