### PR TITLE
fix: add tmux in the base docker image, fixes #78.

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
   software-properties-common \
   sudo \
   telnet \
+  tmux \
   traceroute \
   unzip \
   vim \


### PR DESCRIPTION
## The Issue

Add tmux to apt install #78 

## How This PR Solves The Issue

This adds tmux in the base docker image.

## Manual Testing Instructions

- make build
- make test
-  docker run --rm ddev/coder-ddev:$(cat VERSION) tmux -V

Should return: `tmux 3.4`