### PR TITLE
fix: Add a wrapper for php binary on the base docker image. Fixes #74

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -158,6 +158,10 @@ RUN curl -fsSL https://pkg.ddev.com/apt/gpg.key | gpg --dearmor -o /etc/apt/keyr
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ddev && \
   rm -rf /var/lib/apt/lists/*
 
+# Wrapper so system tools (e.g. phpcs) can invoke PHP via DDEV
+RUN printf '#!/usr/bin/env bash\nddev php "$@"\n' > /usr/local/bin/php && \
+  chmod +x /usr/local/bin/php
+
 RUN mkdir -p /home/linuxbrew/.linuxbrew && chown -R coder:coder /home/linuxbrew/
 
 USER coder


### PR DESCRIPTION
## The Issue

#74 Add default /usr/local/bin/php executable file

## How This PR Solves The Issue

To help with static analysis tools like phpcs, we're adding a wrapper named php that actually calls the php binary inside the ddev container.

## Manual Testing Instructions
- make build
- make test
- docker run -it --rm ddev/coder-ddev:$(cat VERSION) php -i 

Using default configuration, you should get an error similar to : `Docker error: failed to connect to the docker API` which means `php` is really calling `ddev`.