### PR TITLE
feat: make vscode extensions configurable when creating a new workspace, fixes #42

### DIFF
--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -130,6 +130,25 @@ data "coder_parameter" "install_profile" {
   }
 }
 
+data "coder_parameter" "vscode_extensions" {
+  name         = "vscode_extensions"
+  display_name = "VS Code Extensions"
+  description  = "Select extensions to enable in VS Code for Web"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode([for e in var.vscode_extensions : e.id if e.default])
+  mutable      = true
+  order        = 100
+
+  dynamic "option" {
+    for_each = var.vscode_extensions
+    content {
+      name  = option.value.name
+      value = option.value.id
+    }
+  }
+}
+
 
 
 # Workspace data source
@@ -148,6 +167,7 @@ locals {
   # Determine workspace home path
   # Sysbox Strategy: Use standard /home/coder
   workspace_home   = "/home/coder"
+  selected_extensions = jsondecode(data.coder_parameter.vscode_extensions.value)
   issue_fork_clean = trimprefix(data.coder_parameter.issue_fork.value, "drupal-")
   issue_url        = local.issue_fork_clean != "" ? "https://www.drupal.org/project/drupal/issues/${local.issue_fork_clean}" : ""
 }
@@ -163,6 +183,31 @@ locals {
   # Note: We can't use regex, so we handle the most common cases
   registry_without_version      = replace(var.workspace_image_registry, ":${local.image_version}", "")
   workspace_image_registry_base = replace(local.registry_without_version, ":latest", "")
+}
+
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
 }
 
 variable "workspace_image_registry" {
@@ -1445,17 +1490,7 @@ module "vscode-web" {
   folder         = "/home/coder/drupal-core"
   accept_license = true
   order          = 2
-  extensions     = [
-    "xdebug.php-debug",
-    "bmewburn.vscode-intelephense-client",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "sanderronde.phpstan-vscode",
-    "streetsidesoftware.code-spell-checker",
-    "stylelint.vscode-stylelint",
-    "valeryanm.vscode-phpsab",
-    "biati.ddev-manager",
-  ]
+  extensions     = local.selected_extensions
 }
 
 # DDEV Web Server (HTTP) - appears when DDEV project is running

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -59,12 +59,58 @@ variable "docker_gid" {
 data "coder_workspace" "me" {}
 data "coder_workspace_owner" "me" {}
 
+# Per-workspace user parameters (shown in workspace creation UI)
+data "coder_parameter" "vscode_extensions" {
+  name         = "vscode_extensions"
+  display_name = "VS Code Extensions"
+  description  = "Select extensions to enable in VS Code for Web"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode([for e in var.vscode_extensions : e.id if e.default])
+  mutable      = true
+  order        = 100
+
+  dynamic "option" {
+    for_each = var.vscode_extensions
+    content {
+      name  = option.value.name
+      value = option.value.id
+    }
+  }
+}
+
 locals {
   workspace_home = "/home/coder"
+  selected_extensions = jsondecode(data.coder_parameter.vscode_extensions.value)
   image_version  = try(trimspace(file("${path.module}/VERSION")), var.image_version)
 
   registry_without_version      = replace(var.workspace_image_registry, ":${local.image_version}", "")
   workspace_image_registry_base = replace(local.registry_without_version, ":latest", "")
+}
+
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
 }
 
 variable "workspace_image_registry" {
@@ -347,17 +393,7 @@ module "vscode-web" {
   folder         = "/home/coder/${data.coder_workspace.me.name}"
   accept_license = true
   order          = 2
-  extensions     = [
-    "xdebug.php-debug",
-    "bmewburn.vscode-intelephense-client",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "sanderronde.phpstan-vscode",
-    "streetsidesoftware.code-spell-checker",
-    "stylelint.vscode-stylelint",
-    "valeryanm.vscode-phpsab",
-    "biati.ddev-manager",
-  ]
+  extensions     = local.selected_extensions
 }
 
 # Slug matches the workspace name, which is also the DDEV project name.

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -68,6 +68,25 @@ data "coder_workspace" "me" {}
 
 # Workspace owner data source (Coder v2+)
 data "coder_workspace_owner" "me" {}
+# Per-workspace user parameters (shown in workspace creation UI)
+data "coder_parameter" "vscode_extensions" {
+  name         = "vscode_extensions"
+  display_name = "VS Code Extensions"
+  description  = "Select extensions to enable in VS Code for Web"
+  type         = "list(string)"
+  form_type    = "multi-select"
+  default      = jsonencode([for e in var.vscode_extensions : e.id if e.default])
+  mutable      = true
+  order        = 100
+
+  dynamic "option" {
+    for_each = var.vscode_extensions
+    content {
+      name  = option.value.name
+      value = option.value.id
+    }
+  }
+}
 
 
 
@@ -79,6 +98,7 @@ locals {
   # Determine workspace home path
   # Sysbox Strategy: Use standard /home/coder
   workspace_home = "/home/coder"
+  selected_extensions = jsondecode(data.coder_parameter.vscode_extensions.value)
 }
 
 locals {
@@ -92,6 +112,31 @@ locals {
   # Note: We can't use regex, so we handle the most common cases
   registry_without_version      = replace(var.workspace_image_registry, ":${local.image_version}", "")
   workspace_image_registry_base = replace(local.registry_without_version, ":latest", "")
+}
+
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
 }
 
 variable "workspace_image_registry" {
@@ -525,17 +570,7 @@ module "vscode-web" {
   folder         = "/home/coder"
   accept_license = true
   order          = 2
-  extensions     = [
-    "xdebug.php-debug",
-    "bmewburn.vscode-intelephense-client",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "sanderronde.phpstan-vscode",
-    "streetsidesoftware.code-spell-checker",
-    "stylelint.vscode-stylelint",
-    "valeryanm.vscode-phpsab",
-    "biati.ddev-manager",
-  ]
+  extensions     = local.selected_extensions
 }
 
 # DDEV Web Server (HTTP) - appears when DDEV project is running


### PR DESCRIPTION
## The Issue

Fix #42 A few more suggestions for extensions to add to VSCode

## How This PR Solves The Issue

This move the hardcoded enabled vscode extensions into a terraform variable. Users can select which vscode extensions to have enabled by default when creating the workspace.

## Manual Testing Instructions

- make build
- make test
- make push-template-drupal-core
- Create a new workspace based on the drupal-core template.
  In the creation screen process, select the Github extension
  
<img width="580" height="192" alt="Screenshot 2026-04-24 at 10-50-26 Create workspace - Coder" src="https://github.com/user-attachments/assets/acf8adf2-76ea-4f59-81d8-7566313b5951" />
- When the workspace is ready, open VS Code Web
- Make sure Github extension is showing up on the left side
<img width="125" height="157" alt="image" src="https://github.com/user-attachments/assets/2614bbab-f969-47d9-83fe-c00fdaab9326" />