### PR TITLE
docs: fix GitHub OAuth — create app under org, disable device flow with allowed-orgs

### DIFF
--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -576,11 +576,12 @@ The initial admin account must be created with username/password via the web UI 
 
 **1. Create a GitHub OAuth App**
 
-Go to [GitHub Developer Settings → OAuth Apps → New OAuth App](https://github.com/settings/developers) and fill in:
+Create the app under your **GitHub organization**, not your personal account — apps created under a personal account show "by \<username\>" on the authorization screen instead of "by \<org\>". Go to **github.com/organizations/\<your-org\>/settings/applications → New OAuth App** and fill in:
 
 - **Application name**: `Coder (coder.ddev.com)` (or similar)
 - **Homepage URL**: `https://coder.ddev.com`
 - **Authorization callback URL**: `https://coder.ddev.com/api/v2/users/oauth2/github/callback`
+- **Enable Device Flow**: leave unchecked (see note below)
 
 After creating the app, generate a client secret. Note the **Client ID** and **Client Secret**.
 
@@ -600,6 +601,8 @@ CODER_OAUTH2_GITHUB_ALLOWED_ORGS=ddev
 # Or allow any GitHub user (not recommended for a shared server):
 # CODER_OAUTH2_GITHUB_ALLOW_EVERYONE=true
 ```
+
+> **Device Flow:** Do not set `CODER_OAUTH2_GITHUB_DEVICE_FLOW=true` when `CODER_OAUTH2_GITHUB_ALLOWED_ORGS` is set. Device flow routes all GitHub logins through a code-based flow that does not request `read:org` scope — org membership checks fail with a 403 and users cannot log in.
 
 **3. Restart Coder**
 


### PR DESCRIPTION
## Summary

Two issues found during staging-coder.ddev.com GitHub OAuth setup:

- **Create OAuth App under the org, not personal account.** Apps created under a personal account show "by \<username\>" on GitHub's authorization screen. Creating under the organization shows "by \<org\>", which is more appropriate for a shared server.
- **Device flow is incompatible with `CODER_OAUTH2_GITHUB_ALLOWED_ORGS`.** Setting `CODER_OAUTH2_GITHUB_DEVICE_FLOW=true` routes all GitHub OAuth logins through the device code flow, which does not request `read:org` scope. Coder needs that scope to verify org membership — without it every login fails with a 403 from GitHub's `/user/memberships/orgs` endpoint. Added a warning to the env config example.

## Test plan

- [x] Verified on staging-coder.ddev.com: device flow disabled, org app created under ddev org, GitHub OAuth login succeeds and org membership check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)