### PR TITLE
feat: restore drush for Drupal main branch (drush/drush now compatible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,15 @@ TEMPLATES := user-defined-web drupal-core freeform
 # Host path to the drupal-core seed cache (bind-mounted read-only into workspaces).
 # This path is specific to the server where the template is deployed.
 # Override with: make push-template-drupal-core DRUPAL_CACHE_PATH=/other/path/drupal-core-seed
-DRUPAL_CACHE_PATH ?= /home/rfay/cache/drupal-core-seed
+DRUPAL_CACHE_PATH ?= /home/rfay/cache/drupal-core-seed ##v Host path to drupal-core seed cache; override per-server
+
+# Whether to activate the pushed template version immediately.
+# Set to false to push for testing before promoting:
+#   make push-template-drupal-core ACTIVATE=false
+#   coder templates versions list drupal-core          # grab the new version name
+#   coder create --template drupal-core --template-version <version> test-ws --yes
+#   coder templates versions promote drupal-core <version>
+ACTIVATE ?= true ##v Set to false to push a template version without activating it (test before promoting)
 
 # Full image tag
 IMAGE_TAG := $(IMAGE_NAME):$(VERSION)
@@ -36,7 +44,7 @@ define push_template
 	@echo "Syncing VERSION to $(1)..."
 	cp VERSION $(1)/VERSION
 	@echo "Pushing Coder template $(1)..."
-	coder templates push --directory $(1) $(1) --yes $(TEMPLATE_VARS_$(1))
+	coder templates push --directory $(1) $(1) --yes --activate=$(ACTIVATE) $(TEMPLATE_VARS_$(1))
 	@echo "Setting template metadata for $(1)..."
 	coder templates edit $(1) --yes $(TEMPLATE_EDIT_$(1))
 	@echo "Template $(1) push complete"
@@ -47,10 +55,13 @@ endef
 
 .PHONY: help
 help: ## Show this help message
-	@echo "Usage: make [target]"
+	@echo "Usage: make [target] [VAR=value ...]"
 	@echo ""
 	@echo "Targets:"
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-42s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Variables (override on command line, e.g. make push-template-drupal-core ACTIVATE=false):"
+	@grep -E '^[A-Z_]+ \?=.*##v .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = " \\?=.*##v "}; {printf "  %-42s %s\n", $$1, $$2}'
 
 .PHONY: build
 build: ## Build Docker image with cache

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -262,6 +262,32 @@ make deploy-user-defined-web
 # Users must rebuild workspaces to get new Docker image
 ```
 
+### Testing a Template Change Before Activating
+
+Push a new version without making it the default, test it on a single workspace, then promote it when satisfied. This lets you validate changes without affecting other users.
+
+```bash
+# 1. Push without activating
+make push-template-drupal-core ACTIVATE=false
+
+# 2. Find the new version name (top row, status "Unused")
+coder templates versions list drupal-core
+
+# 3. Create a test workspace pinned to that version
+coder create --template drupal-core --template-version <version-name> test-workspace --yes
+
+# 4. Verify — e.g. for drupal-core, check setup completed correctly
+coder ssh test-workspace -- grep -E "Drush|Drupal install" ~/drupal-core/drupal-setup.log
+
+# 5. Promote to active once satisfied
+coder templates versions promote drupal-core <version-name>
+
+# 6. Clean up test workspace
+coder delete test-workspace --yes
+```
+
+If you push again with `ACTIVATE=true` (the default) rather than using `promote`, that also activates the version — the `promote` step is only needed when you pushed with `ACTIVATE=false` and want to activate without re-pushing.
+
 ### Rolling Back
 
 ```bash

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -669,7 +669,6 @@ COMPOSE_EOF
     fi
     USING_ISSUE_FORK=false
     SETUP_FAILED=false
-    MANUAL_INSTALL_NEEDED=false
     if [ -n "$ISSUE_FORK" ] || [ -n "$ISSUE_BRANCH" ]; then
       USING_ISSUE_FORK=true
       log_setup "Issue fork mode: ISSUE_FORK=$ISSUE_FORK  ISSUE_BRANCH=$ISSUE_BRANCH  INSTALL_PROFILE=$INSTALL_PROFILE"
@@ -800,14 +799,7 @@ WELCOME_STATIC
         log_setup "Issue fork: creating project structure (dependencies installed after branch checkout)..."
         update_status "⏳ DDEV composer create-project: In progress..."
 
-        # Use rfay/drupal-core-development-project for main branch (no drush/drush)
-        if [ "$DRUPAL_BRANCH" = "main" ]; then
-          COMPOSER_CMD='ddev composer create-project --repository='"'"'{"type":"vcs","url":"https://github.com/rfay/drupal-core-development-project"}'"'"' --no-install --stability=dev --no-interaction joachim-n/drupal-core-development-project .'
-        else
-          COMPOSER_CMD='ddev composer create-project --no-install --no-interaction "joachim-n/drupal-core-development-project:dev-main" .'
-        fi
-
-        if eval "$COMPOSER_CMD" >> "$SETUP_LOG" 2>&1; then
+        if ddev composer create-project --no-install --no-interaction "joachim-n/drupal-core-development-project:dev-main" . >> "$SETUP_LOG" 2>&1; then
           log_setup "✓ Project structure created ($((SECONDS - _t))s)"
           update_status "✓ DDEV composer create-project: Success"
           DRUPAL_SETUP_NEEDED=true
@@ -823,11 +815,7 @@ WELCOME_STATIC
           update_status "✗ DDEV composer create-project: Failed"
           update_status ""
           update_status "Manual recovery:"
-          if [ "$DRUPAL_BRANCH" = "main" ]; then
-            update_status "  cd $DRUPAL_DIR && ddev composer create-project --repository='{\"type\":\"vcs\",\"url\":\"https://github.com/rfay/drupal-core-development-project\"}' --no-install --stability=dev joachim-n/drupal-core-development-project ."
-          else
-            update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project:dev-main\" ."
-          fi
+          update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project:dev-main\" ."
         fi
       elif [ "$NEEDS_NONMAIN_CHECKOUT" = "true" ]; then
         # Non-main version (10.x/11.x) without cache: create project structure then checkout branch.
@@ -856,14 +844,7 @@ WELCOME_STATIC
         log_setup "No cache available, running full composer create (this takes 5-10 minutes)..."
         update_status "⏳ DDEV composer create: In progress (this takes 5-10 minutes)..."
 
-        # Use rfay/drupal-core-development-project for main branch (no drush/drush)
-        if [ "$DRUPAL_BRANCH" = "main" ]; then
-          COMPOSER_CMD='ddev composer create-project --repository='"'"'{"type":"vcs","url":"https://github.com/rfay/drupal-core-development-project"}'"'"' --stability=dev --no-interaction joachim-n/drupal-core-development-project'
-        else
-          COMPOSER_CMD='ddev composer create joachim-n/drupal-core-development-project --no-interaction'
-        fi
-
-        if eval "$COMPOSER_CMD" >> "$SETUP_LOG" 2>&1; then
+        if ddev composer create joachim-n/drupal-core-development-project --no-interaction >> "$SETUP_LOG" 2>&1; then
           log_setup "✓ Drupal core development project created ($((SECONDS - _t))s)"
           update_status "✓ DDEV composer create: Success"
           DRUPAL_SETUP_NEEDED=true
@@ -873,11 +854,7 @@ WELCOME_STATIC
           update_status "✗ DDEV composer create: Failed"
           update_status ""
           update_status "Manual recovery:"
-          if [ "$DRUPAL_BRANCH" = "main" ]; then
-            update_status "  cd $DRUPAL_DIR && ddev composer create-project --repository='{\"type\":\"vcs\",\"url\":\"https://github.com/rfay/drupal-core-development-project\"}' --stability=dev joachim-n/drupal-core-development-project"
-          else
-            update_status "  cd $DRUPAL_DIR && ddev composer create joachim-n/drupal-core-development-project"
-          fi
+          update_status "  cd $DRUPAL_DIR && ddev composer create joachim-n/drupal-core-development-project"
         fi
       fi
     fi
@@ -1044,22 +1021,20 @@ WELCOME_STATIC
         update_status "⚠ Setup incomplete — see drupal-setup.log for details"
       else
 
-      # Step 5: Ensure Drush is available (not applicable to main branch — removed in Step 4.1)
-      if [ "$DRUPAL_BRANCH" != "main" ]; then
-        if [ -f "vendor/bin/drush" ]; then
-          log_setup "✓ Drush already present"
-          update_status "✓ Drush install: Already present"
+      # Step 5: Ensure Drush is available
+      if [ -f "vendor/bin/drush" ]; then
+        log_setup "✓ Drush already present"
+        update_status "✓ Drush install: Already present"
+      else
+        _t=$SECONDS
+        log_setup "Adding Drush..."
+        update_status "⏳ Drush install: In progress..."
+        if ddev composer require drush/drush -W >> "$SETUP_LOG" 2>&1; then
+          log_setup "✓ Drush configured"
+          update_status "✓ Drush install: Success"
         else
-          _t=$SECONDS
-          log_setup "Adding Drush..."
-          update_status "⏳ Drush install: In progress..."
-          if ddev composer require drush/drush -W >> "$SETUP_LOG" 2>&1; then
-            log_setup "✓ Drush configured"
-            update_status "✓ Drush install: Success"
-          else
-            log_setup "⚠ Warning: Failed to configure Drush"
-            update_status "⚠ Drush install: Warning"
-          fi
+          log_setup "⚠ Warning: Failed to configure Drush"
+          update_status "⚠ Drush install: Warning"
         fi
       fi
 
@@ -1081,29 +1056,24 @@ WELCOME_STATIC
       if ddev drush status 2>/dev/null | grep -q "Drupal bootstrap.*Successful"; then
         log_setup "✓ Drupal already installed"
         update_status "✓ Drupal install: Already present"
-      elif [ "$DRUPAL_BRANCH" = "main" ]; then
-        # main branch: drush si not yet compatible; load seed DB for all cases (issue fork or plain)
-        if [ -f "$CACHE_SEED/.tarballs/db.sql.gz" ]; then
-          _t=$SECONDS
-          log_setup "Loading seed database (main branch)..."
-          update_status "⏳ Drupal install: Loading seed database..."
-          if gzip -dc "$CACHE_SEED/.tarballs/db.sql.gz" | ddev mysql >> "$SETUP_LOG" 2>&1; then
-            log_setup "✓ Seed database loaded ($((SECONDS - _t))s)"
-            log_setup ""
-            log_setup "   Admin Credentials:"
-            log_setup "      Username: admin"
-            log_setup "      Password: admin"
-            log_setup ""
-            update_status "✓ Drupal install: Loaded from seed"
-          else
-            log_setup "⚠ Seed DB load failed ($((SECONDS - _t))s)..."
-            update_status "⚠ Drupal install: Seed DB load failed — manual install required"
-            MANUAL_INSTALL_NEEDED=true
-          fi
+      elif [ "$USING_ISSUE_FORK" = "false" ] && [ -f "$CACHE_SEED/.tarballs/db.sql.gz" ]; then
+        # Fast path: load seed DB for non-issue-fork workspaces when cache is available.
+        # The seed was built with demo_umami + current main, so the schema matches.
+        _t=$SECONDS
+        log_setup "Loading seed database (fast path)..."
+        update_status "⏳ Drupal install: Loading seed database..."
+        if gzip -dc "$CACHE_SEED/.tarballs/db.sql.gz" | ddev mysql >> "$SETUP_LOG" 2>&1; then
+          log_setup "✓ Seed database loaded ($((SECONDS - _t))s)"
+          log_setup ""
+          log_setup "   Admin Credentials:"
+          log_setup "      Username: admin"
+          log_setup "      Password: admin"
+          log_setup ""
+          update_status "✓ Drupal install: Loaded from seed"
         else
-          log_setup "⚠ Drupal main branch: no seed DB available. Manual install required."
-          update_status "⚠ Drupal install: Manual install required (see WELCOME.txt)"
-          MANUAL_INSTALL_NEEDED=true
+          log_setup "⚠ Seed DB load failed ($((SECONDS - _t))s), falling back to drush si..."
+          update_status "⚠ Drupal install: Seed load failed, running drush si..."
+          ddev drush si -y "$INSTALL_PROFILE" --account-pass=admin --site-name="$SITE_NAME" >> "$SETUP_LOG" 2>&1 || true
         fi
       else
         _t=$SECONDS
@@ -1134,53 +1104,9 @@ WELCOME_STATIC
       fi
       fi # end SETUP_FAILED guard
 
-      # Step 6.5: Append manual install instructions to WELCOME.txt when drush si was skipped
-      if [ "$MANUAL_INSTALL_NEEDED" = "true" ]; then
-        # Compute the site URL using the same domain logic as the launch command
-        _INSTALL_URL=""
-        if [ -n "$CODER_WORKSPACE_NAME" ]; then
-          if [ -n "$VSCODE_PROXY_URI" ]; then
-            _CODER_DOMAIN=$(echo "$VSCODE_PROXY_URI" | sed -E 's|https?://[^.]+\.(.+?)(/.*)?$|\1|')
-          elif [ -n "$CODER_AGENT_URL" ]; then
-            _CODER_DOMAIN=$(echo "$CODER_AGENT_URL" | sed -E 's|https?://(.+?)(/.*)?$|\1|')
-          fi
-          if [ -n "$${_CODER_DOMAIN:-}" ]; then
-            _SITE_URL="https://drupal-site--$${CODER_WORKSPACE_NAME}--$${CODER_WORKSPACE_OWNER_NAME}.$${_CODER_DOMAIN}"
-          fi
-        fi
-        {
-          echo ""
-          echo "⚠ MANUAL DRUPAL INSTALL REQUIRED"
-          echo "================================="
-          echo "drush site-install is not yet compatible with Drupal main branch."
-          echo "Composer and DDEV are fully set up. To finish:"
-          echo ""
-          echo "1. Visit the site URL:"
-          if [ -n "$${_SITE_URL:-}" ]; then
-            echo "   $_SITE_URL"
-          fi
-          echo ""
-          echo "2. Drupal will redirect you to the web installer."
-          echo "   Follow the installation wizard."
-          echo ""
-          echo "3. On the database configuration page, use these settings:"
-          echo "   Database name: db"
-          echo "   Database user: db"
-          echo "   Database password: db"
-          echo "   Host: db"
-          echo "   (Leave port and table prefix as defaults)"
-          echo ""
-          echo "After install, run:  ddev launch  (shows site URL and admin login)"
-        } >> ~/WELCOME.txt
-        log_setup "⚠ Manual Drupal install required — instructions added to WELCOME.txt"
-        update_status "⚠ Setup complete — manual Drupal install required (see WELCOME.txt)"
-      fi
-
-      # Step 6.5: Cache rebuild — non-main only (drush not available on main branch)
-      if [ "$MANUAL_INSTALL_NEEDED" != "true" ] && [ "$DRUPAL_BRANCH" != "main" ]; then
-        log_setup "Running cache rebuild..."
-        ddev drush cr >> "$SETUP_LOG" 2>&1 || true
-      fi
+      # Step 6.5: Cache rebuild — ensures a clean state after any setup path
+      log_setup "Running cache rebuild..."
+      ddev drush cr >> "$SETUP_LOG" 2>&1 || true
 
       # Step 6.6: Set up phpunit.xml for running core tests (numbered was originally 6.6, now follows 6.5)
       if [ ! -f "phpunit.xml" ] && [ -f "phpunit-ddev.xml" ]; then


### PR DESCRIPTION
## Summary

- **Removes the March 2026 workarounds** that were added when `drush/drush` was temporarily incompatible with Drupal 12/main. Now that drush works again, the template is back to the original uniform approach.
- **Adds `ACTIVATE` Makefile variable** so any `push-template-*` target can push without activating (`ACTIVATE=false`), enabling safe staging tests before promotion.
- **Documents the test workflow** in the operations guide.

### Template changes (`drupal-core/template.tf`)

- Removes `rfay/drupal-core-development-project` fork usage (was needed to exclude drush from composer); both issue-fork and full-create paths now use `joachim-n/drupal-core-development-project` unconditionally
- Step 5 (drush install) is now unconditional — no longer skipped for main branch
- Step 6 (DB install): seed DB fast path is now gated on `USING_ISSUE_FORK=false` only (not branch); issue forks on main now correctly run `drush si` instead of loading the seed DB
- Removes the `MANUAL_INSTALL_NEEDED` code path and manual install instructions from `WELCOME.txt`
- Step 6.5 (`drush cr`) is now unconditional

### Makefile changes

- Adds `ACTIVATE ?= true` variable; threads `--activate=$(ACTIVATE)` through the shared `push_template` function — default behavior unchanged
- Adds `##v` marker convention for self-documenting variables in `make help` output

### Docs changes

- New "Testing a Template Change Before Activating" section in `docs/admin/operations-guide.md` with the full 6-step workflow

## Test plan

- [ ] `make push-template-drupal-core ACTIVATE=false` — pushes without activating; `coder templates versions list drupal-core` shows new version as `Unused`
- [ ] Create workspace from inactive version; verify setup log shows `✓ Drush already present` and `✓ Drupal install: Loaded from seed` (main, no issue fork)
- [ ] Create issue-fork workspace on main; verify setup log shows `✓ Drupal installed` (drush si path)
- [ ] Create 10.x or 11.x workspace; verify drush si still works on stable branches
- [ ] Confirm no "MANUAL DRUPAL INSTALL REQUIRED" text in any `WELCOME.txt`
- [ ] `make help` shows Variables section with `ACTIVATE` and `DRUPAL_CACHE_PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)