### PR TITLE
fix: update-drupal-cache — ddev poweroff/start -y/drush, no hardcoded paths, coder.env cleanup, fixes #92

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TEMPLATES := user-defined-web drupal-core freeform
 # Host path to the drupal-core seed cache (bind-mounted read-only into workspaces).
 # This path is specific to the server where the template is deployed.
 # Override with: make push-template-drupal-core DRUPAL_CACHE_PATH=/other/path/drupal-core-seed
-DRUPAL_CACHE_PATH ?= /home/rfay/cache/drupal-core-seed ##v Host path to drupal-core seed cache; override per-server
+DRUPAL_CACHE_PATH ?= $(HOME)/cache/drupal-core-seed ##v Host path to drupal-core seed cache; override per-server
 
 # Whether to activate the pushed template version immediately.
 # Set to false to push for testing before promoting:

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -677,7 +677,7 @@ DDEV must be installed on the Coder server itself (not just inside workspaces). 
 
 Follow the [DDEV Linux installation instructions](https://docs.ddev.com/en/stable/users/install/ddev-installation/#ddev-installation-linux) to install DDEV on the host.
 
-> **User note:** The seed cache must be owned and operated by a normal (non-root) user. DDEV refuses to run as root. All the commands below, and the systemd service, must run as that user — not with `sudo`. On this server the user is `rfay`; adjust for your own setup.
+> **User note:** The seed cache must be owned and operated by a normal (non-root) user. DDEV refuses to run as root. All the commands below, and the systemd service, must run as that user — not with `sudo`.
 
 ### One-time initial setup
 
@@ -734,9 +734,11 @@ sudo install -m 644 $REPO/drupal-core/scripts/drupal-cache-updater.service \
 sudo install -m 644 $REPO/drupal-core/scripts/drupal-cache-updater.timer \
   /etc/systemd/system/
 
-# If your seed directory or cache user differs from the defaults, edit the service:
+# Edit the service to set the correct user (required — YOURUSER is a placeholder):
+sudo sed -i "s/User=YOURUSER/User=$(whoami)/" /etc/systemd/system/drupal-cache-updater.service
+# If your seed directory differs from ~/cache/drupal-core-seed, also add --seed-dir:
 #   sudo vim /etc/systemd/system/drupal-cache-updater.service
-# See the comments in that file for User and --seed-dir guidance.
+# and change ExecStart to: /usr/local/bin/update-drupal-cache --seed-dir /your/cache/path
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now drupal-cache-updater.timer
@@ -762,24 +764,12 @@ journalctl -u drupal-cache-updater.service -f
 
 ### Template variable
 
-The template uses a `cache_path` variable for the host-side seed directory. The default in both `drupal-core/template.tf` and the `Makefile` is currently hardcoded to the path on this server (`/home/rfay/cache/drupal-core-seed`), so `make push-template-drupal-core` works without any override on this server.
+The template uses a `cache_path` variable for the host-side seed directory. The `Makefile` defaults `DRUPAL_CACHE_PATH` to `~/cache/drupal-core-seed` (resolved to the home directory of whoever runs `make`), so `make push-template-drupal-core` works without any override as long as your seed directory is at that path.
 
-**On a different server or with a different user**, update the defaults before deploying:
-
-```bash
-# In Makefile, change:
-DRUPAL_CACHE_PATH ?= /home/youruser/cache/drupal-core-seed
-
-# In drupal-core/template.tf, change:
-variable "cache_path" {
-  default = "/home/youruser/cache/drupal-core-seed"
-}
-```
-
-Or override at deploy time without changing files:
+If your seed directory is elsewhere, override at deploy time:
 
 ```bash
-make push-template-drupal-core DRUPAL_CACHE_PATH=/home/youruser/cache/drupal-core-seed
+make push-template-drupal-core DRUPAL_CACHE_PATH=/your/cache/path
 ```
 
 ### How new workspaces use the cache

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -503,27 +503,30 @@ sudo vim /etc/coder.d/coder.env
 
 #### Listening on port 443 (recommended for production)
 
-Coder terminates TLS itself — no reverse proxy needed:
+Coder terminates TLS itself — no reverse proxy needed. Replace `coder.example.com` with your actual hostname throughout:
 
 ```bash
-# Externally-reachable URL
-CODER_ACCESS_URL=https://coder.ddev.com
+# Externally-reachable URL — replace with your hostname
+CODER_ACCESS_URL=https://coder.example.com
 
 # Serve HTTPS directly on port 443
 CODER_TLS_ENABLE=true
 CODER_TLS_ADDRESS=0.0.0.0:443
-CODER_TLS_CERT_FILE=/etc/letsencrypt/live/coder.ddev.com/fullchain.pem
-CODER_TLS_KEY_FILE=/etc/letsencrypt/live/coder.ddev.com/privkey.pem
+CODER_TLS_CERT_FILE=/etc/letsencrypt/live/coder.example.com/fullchain.pem
+CODER_TLS_KEY_FILE=/etc/letsencrypt/live/coder.example.com/privkey.pem
 
 # Redirect HTTP on port 80 to HTTPS
 CODER_HTTP_ADDRESS=0.0.0.0:80
 CODER_REDIRECT_TO_ACCESS_URL=true
 
-# Wildcard domain for workspace app subdomain routing (requires *.coder.ddev.com DNS + cert)
-CODER_WILDCARD_ACCESS_URL=*.coder.ddev.com
+# Wildcard domain for workspace app subdomain routing (requires *.coder.example.com DNS + cert)
+CODER_WILDCARD_ACCESS_URL=*.coder.example.com
 
-# PostgreSQL connection (set up in Step 5)
+# PostgreSQL connection (set up in Step 5) — replace the password
 CODER_PG_CONNECTION_URL=postgresql://coder:strongpasswordhere@localhost/coder?sslmode=disable
+
+# Telemetry — disable if you prefer not to send usage data to Coder
+CODER_TELEMETRY=false
 ```
 
 #### Alternative: plain HTTP or non-standard port
@@ -531,7 +534,7 @@ CODER_PG_CONNECTION_URL=postgresql://coder:strongpasswordhere@localhost/coder?ss
 If you're running behind a reverse proxy (nginx, Caddy) that handles TLS, or just testing on a LAN:
 
 ```bash
-CODER_ACCESS_URL=http://coder.ddev.com:3000
+CODER_ACCESS_URL=http://coder.example.com:3000
 CODER_HTTP_ADDRESS=0.0.0.0:3000
 # No TLS variables needed; your proxy handles termination
 ```
@@ -551,7 +554,7 @@ journalctl -u coder -f
 
 ### First-run admin setup
 
-Navigate to `https://coder.ddev.com` and create the initial admin user.
+Navigate to `https://coder.example.com` (your hostname) and create the initial admin user.
 
 > **Important:** Use your GitHub username as the Coder username (e.g. `rfay`). When you later log in via GitHub OAuth, Coder matches on username — if the name is already taken it creates a second account with a random suffix (e.g. `rfay-wanderingortiz8`) which will not have admin permissions. Getting the username right here avoids that entirely.
 

--- a/drupal-core/scripts/drupal-cache-updater.service
+++ b/drupal-core/scripts/drupal-cache-updater.service
@@ -7,12 +7,13 @@ Requires=docker.service
 Type=oneshot
 # Must run as the user who owns the seed cache directory — NOT root.
 # DDEV refuses to run as root; this service must run as a normal user.
-# Change User and WorkingDirectory to match the account that owns the cache.
-User=rfay
-WorkingDirectory=/home/rfay
+# Change User= to the account that owns the cache (e.g. your server's admin user).
+User=YOURUSER
+WorkingDirectory=%h
 # The script is installed to /usr/local/bin/ (see docs/admin/server-setup.md).
-# Pass --seed-dir if your seed directory differs from the default.
-ExecStart=/usr/local/bin/update-drupal-cache --seed-dir /home/rfay/cache/drupal-core-seed
+# The script defaults to ~/cache/drupal-core-seed (relative to the User= above).
+# Pass --seed-dir only if your seed directory differs from that default.
+ExecStart=/usr/local/bin/update-drupal-cache
 StandardOutput=journal
 StandardError=journal
 # Allow up to 30 minutes for composer update + site install

--- a/drupal-core/scripts/update-drupal-cache
+++ b/drupal-core/scripts/update-drupal-cache
@@ -17,16 +17,20 @@
 #
 # Options:
 #   --seed-dir PATH   Absolute path to the seed directory.
-#                     Default: /home/rfay/cache/drupal-core-seed
-#                     Must match the cache_path variable set in the Coder template.
+#                     Default: ~/cache/drupal-core-seed (resolved to the running user's home)
+#                     The Coder template's cache_path variable must be set to the same path.
 #
 # Note: This script must run as the user who owns the seed directory (not root).
 # DDEV refuses to run as root. The systemd service (drupal-cache-updater.service)
 # must set User= to the cache owner — see that file and docs/admin/server-setup.md.
+#
+# Note: when run via the systemd timer, the seed directory is taken from the default
+# or from the ExecStart line in drupal-cache-updater.service — edit that file to pass
+# --seed-dir if your seed directory differs from the default.
 
 set -euo pipefail
 
-SEED_DIR="/home/rfay/cache/drupal-core-seed"
+SEED_DIR="${HOME}/cache/drupal-core-seed"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -61,11 +65,9 @@ echo ""
 
 cd "$SEED_DIR"
 
-# Ensure DDEV project is running
-if ! ddev describe 2>/dev/null | grep -q "OK"; then
-  echo "Starting DDEV seed project..."
-  ddev start
-fi
+echo "Starting DDEV seed project..."
+ddev poweroff
+ddev start -y
 
 pushd ${SEED_DIR}/repos/drupal >/dev/null
 git pull
@@ -74,6 +76,8 @@ popd >/dev/null
 # Update composer dependencies (also updates repos/drupal git checkout via path repo)
 echo "Running composer update..."
 ddev composer update --with-all-dependencies
+
+ddev composer require drush/drush
 
 # Fresh site install so the exported snapshot matches the updated codebase
 echo "Running site install..."

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -61,7 +61,6 @@ variable "docker_gid" {
 variable "cache_path" {
   description = "Host path to the drupal-core seed cache directory (mounted read-only into workspaces)"
   type        = string
-  default     = "/home/rfay/cache/drupal-core-seed"
 }
 
 # Per-workspace user parameters (shown in workspace creation UI, pre-fillable via ?param.name=value URL)


### PR DESCRIPTION
## Summary

- `update-drupal-cache`: add `ddev poweroff` + `ddev start -y` before update, add `ddev composer require drush/drush`, change default `SEED_DIR` from hardcoded `/home/rfay/...` to `${HOME}/cache/drupal-core-seed` — fixes #92
- `drupal-cache-updater.service`: replace `User=rfay`/hardcoded paths with `User=YOURUSER`/`%h` placeholder; drop explicit `--seed-dir` from `ExecStart` (script default now correct)
- `drupal-core/template.tf`: remove hardcoded `/home/rfay/cache/drupal-core-seed` default from `cache_path` variable
- `Makefile`: `DRUPAL_CACHE_PATH` default changed from `/home/rfay/...` to `$(HOME)/cache/drupal-core-seed`
- `docs/admin/server-setup.md`: replace `coder.ddev.com` with `coder.example.com` in `coder.env` examples, add `CODER_TELEMETRY=false`, update service install instructions to sed-substitute `YOURUSER`

## Test plan

- [x] Ran `update-drupal-cache` on staging-coder.ddev.com — completed successfully in ~1.5 min (composer update + drush si + export-db)

🤖 Generated with [Claude Code](https://claude.com/claude-code)