### PR TITLE
feat: add push-all-templates target, simplify deploy-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,10 @@ push-template-drupal-core: ## Push drupal-core template to Coder
 push-template-freeform: ## Push freeform template to Coder
 	$(call push_template,freeform)
 
+.PHONY: push-all-templates
+push-all-templates: push-template-user-defined-web push-template-drupal-core push-template-freeform ## Push all templates to Coder (no image build)
+	@echo "All templates pushed!"
+
 # --- Deploy targets ---
 
 .PHONY: deploy-user-defined-web
@@ -150,5 +154,5 @@ deploy-freeform: push-template-freeform ## Deploy freeform template (uses existi
 	@echo "Deployment of freeform complete!"
 
 .PHONY: deploy-all
-deploy-all: deploy-user-defined-web push-template-drupal-core push-template-freeform ## Deploy image and all templates
+deploy-all: build-and-push push-all-templates ## Build image, push image, and push all templates
 	@echo "All templates deployed!"


### PR DESCRIPTION
## Summary

- Adds `push-all-templates` target that pushes all three templates to Coder without rebuilding the image — useful when only template HCL has changed
- Simplifies `deploy-all` to depend on `build-and-push` + `push-all-templates` directly, making the dependency graph explicit rather than burying the image build inside `deploy-user-defined-web`

## Test plan

- [x] `make push-all-templates` — ran successfully, all three templates updated to April 30
- [x] `make help` — both new and updated targets appear with correct descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)