### PR TITLE
fix: failure reporting, allow-plugins, operations docs, workspace sharing docs

### DIFF
--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -88,15 +88,32 @@ See `image/README.md` for details on customizing the Docker image.
 ### Using the Makefile
 
 ```bash
-# Push template only
+# Push all three templates (no image build — use when only HCL changed)
+make push-all-templates
+
+# Push a single template
 make push-template-user-defined-web
+make push-template-drupal-core
+make push-template-freeform
 
-# Full deployment (build image + push image + push template)
-make deploy-user-defined-web
+# Full deployment: build image, push image, push all templates
+make deploy-all
 
-# Full deployment without cache
-make deploy-user-defined-web-no-cache
+# Full deployment without cache (clean image build)
+make build-and-push-no-cache && make push-all-templates
 ```
+
+### Auto-stop TTL
+
+Set a default auto-stop so idle workspaces shut down and free resources. Run once after initial deployment (or after adding a new template):
+
+```bash
+coder templates edit drupal-core      --default-ttl 2h --yes
+coder templates edit user-defined-web --default-ttl 2h --yes
+coder templates edit freeform         --default-ttl 2h --yes
+```
+
+Users can override the TTL on their individual workspaces if needed.
 
 ### Template Configuration
 

--- a/docs/user/using-workspaces.md
+++ b/docs/user/using-workspaces.md
@@ -9,6 +9,7 @@ This guide covers daily workflows, tips, and best practices for working with DDE
 - [DDEV Workflows](#ddev-workflows)
 - [Git Workflows](#git-workflows)
 - [Port Forwarding](#port-forwarding)
+- [Sharing and Collaboration](#sharing-and-collaboration)
 - [Common Tasks](#common-tasks)
 - [Tips and Tricks](#tips-and-tricks)
 - [Performance Optimization](#performance-optimization)
@@ -665,6 +666,60 @@ coder port-forward my-workspace --tcp 3000:3000
 # Access via:
 # http://localhost:3000
 ```
+
+## Sharing and Collaboration
+
+### Sharing Your Workspace
+
+You can share a running workspace with another user for pair programming or review. The recipient gets a live view of your workspace in their browser — same URL, same running site.
+
+**Via the web UI:**
+1. Open your workspace in the Coder dashboard
+2. Click **Share** in the top-right corner
+3. Enter the Coder username to share with and set the permission level
+4. Send them the workspace URL
+
+**Via the CLI:**
+```bash
+# Share with another user (read-only by default)
+coder sharing add <owner>/<workspace> --user <username>
+
+# Example
+coder sharing add rfay/issue-3453474 --user stasadev
+
+# List current shares
+coder sharing list rfay/issue-3453474
+
+# Remove a share
+coder sharing remove rfay/issue-3453474 --user stasadev
+```
+
+See [Coder's shared workspaces docs](https://coder.com/docs/user-guides/shared-workspaces) for full details on permission levels.
+
+### Admin Access
+
+Admins can access any workspace on the server — useful for debugging or support. From the Coder dashboard, admins see all workspaces under **Admin settings → Workspaces** and can SSH into or open any of them.
+
+### Sharing Individual Ports
+
+You can share a specific port (e.g., a site you're working on) without sharing the full workspace:
+
+**Via the web UI:**
+1. Open your workspace
+2. Click **Open ports** (top right of the agent section)
+3. Click the share icon next to the port you want to expose
+4. Set visibility: **Owner** (private), **Authenticated** (any logged-in user), or **Public** (anyone with the URL)
+
+**Via the CLI:**
+```bash
+# List open ports
+coder port-forward <workspace> --list
+
+# Open a port publicly (share the printed URL)
+coder open url <workspace> --port 8080
+```
+
+Public port sharing is handy for quickly showing a site to someone without a Coder account.
 
 ## Common Tasks
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1008,6 +1008,10 @@ WELCOME_STATIC
             log_setup "  Applied composer/composer pin to ~2.8.1 (json-schema conflict detected)"
           fi
 
+          # Allow all Composer plugins — issue fork packages (e.g. symfony/runtime) may
+          # introduce plugins not listed in the project's allow-plugins config.
+          ddev composer config allow-plugins true >> "$SETUP_LOG" 2>&1
+
           # Now resolve dependencies for the checked-out issue branch.
           # Use 'update -W' (not 'install') so composer re-solves the full dependency graph
           # with the new composer.json constraints rather than trying to honour a stale lock file.
@@ -1227,6 +1231,9 @@ LAUNCH_EOF
     TOTAL_TIME=$((SECONDS - SCRIPT_START))
     INSTALL_TIME=$((SECONDS - SETUP_START))
 
+    # Collect failure lines for summary (✗-prefixed lines from the setup log)
+    FAILURE_SUMMARY=$(grep "✗" "$SETUP_LOG" 2>/dev/null | grep -v "^$" | head -20 || true)
+
     # Final status and summary
     update_status ""
     update_status "Completed: $(date)"
@@ -1236,38 +1243,61 @@ LAUNCH_EOF
     update_status "  Install/seed phase:           $${INSTALL_TIME}s"
     update_status "  Total workspace startup:      $${TOTAL_TIME}s"
     update_status ""
+    if [ "$SETUP_FAILED" = "true" ]; then
+      update_status "=========================================="
+      update_status "✗ SETUP FAILED — workspace needs attention"
+      update_status "=========================================="
+      update_status ""
+      update_status "Errors:"
+      echo "$FAILURE_SUMMARY" | while IFS= read -r _line; do update_status "  $_line"; done
+      update_status ""
+      update_status "SSH in and run: cat $SETUP_LOG"
+    fi
+    update_status ""
     update_status "View full logs: $SETUP_LOG"
 
     log_setup ""
     log_setup "=========================================="
-    log_setup "✨ Setup Complete!"
+    if [ "$SETUP_FAILED" = "true" ]; then
+      log_setup "✗ SETUP FAILED — see errors below"
+    else
+      log_setup "✨ Setup Complete!"
+    fi
     log_setup "=========================================="
     log_setup ""
-    log_setup "⏱  Timing Summary:"
-    log_setup "   ddev utility download-images: $${IMAGES_TIME}s"
-    log_setup "   Install/seed phase:           $${INSTALL_TIME}s"
-    log_setup "   Total workspace startup:      $${TOTAL_TIME}s"
-    log_setup ""
-    log_setup "📁 Project Location:"
-    log_setup "   $DRUPAL_DIR"
-    log_setup ""
-    log_setup "🌐 Access Your Site:"
-    log_setup "   - Click 'DDEV Web' in Coder dashboard"
-    log_setup "   - Or run: ddev launch"
-    log_setup ""
-    log_setup "🔐 Admin Credentials:"
-    log_setup "   Username: admin"
-    log_setup "   Password: admin"
-    log_setup ""
-    log_setup "🛠️  Useful Commands:"
-    log_setup "   ddev drush uli          # One-time login link"
-    log_setup "   ddev drush status       # Check Drupal status"
-    log_setup "   ddev logs               # View logs"
-    log_setup "   ddev ssh                # SSH into container"
-    log_setup ""
-    log_setup "📋 Setup Details:"
-    log_setup "   Status: $SETUP_STATUS"
-    log_setup "   Logs:   $SETUP_LOG"
+    if [ "$SETUP_FAILED" = "true" ]; then
+      log_setup "Errors encountered:"
+      echo "$FAILURE_SUMMARY" | while IFS= read -r _line; do log_setup "  $_line"; done
+      log_setup ""
+      log_setup "Full log: cat $SETUP_LOG"
+      log_setup "Status:   cat $SETUP_STATUS"
+    else
+      log_setup "⏱  Timing Summary:"
+      log_setup "   ddev utility download-images: $${IMAGES_TIME}s"
+      log_setup "   Install/seed phase:           $${INSTALL_TIME}s"
+      log_setup "   Total workspace startup:      $${TOTAL_TIME}s"
+      log_setup ""
+      log_setup "📁 Project Location:"
+      log_setup "   $DRUPAL_DIR"
+      log_setup ""
+      log_setup "🌐 Access Your Site:"
+      log_setup "   - Click 'DDEV Web' in Coder dashboard"
+      log_setup "   - Or run: ddev launch"
+      log_setup ""
+      log_setup "🔐 Admin Credentials:"
+      log_setup "   Username: admin"
+      log_setup "   Password: admin"
+      log_setup ""
+      log_setup "🛠️  Useful Commands:"
+      log_setup "   ddev drush uli          # One-time login link"
+      log_setup "   ddev drush status       # Check Drupal status"
+      log_setup "   ddev logs               # View logs"
+      log_setup "   ddev ssh                # SSH into container"
+      log_setup ""
+      log_setup "📋 Setup Details:"
+      log_setup "   Status: $SETUP_STATUS"
+      log_setup "   Logs:   $SETUP_LOG"
+    fi
     log_setup ""
 
     # Create projects directory for additional projects if needed
@@ -1393,21 +1423,46 @@ BASHCOMP
   
     
     
-    echo "=== Setup Complete ==="
-    echo ""
-    echo "⏱  Timing: images=$${IMAGES_TIME}s  install=$${INSTALL_TIME}s  total=$${TOTAL_TIME}s"
-    echo ""
-    echo "📁 Drupal core ready at ~/drupal-core"
-    echo "📄 Welcome message saved to ~/WELCOME.txt"
-    echo ""
-    echo "Next steps:"
-    echo "  1. Click 'DDEV Web' app to access your site"
-    echo "  2. Log in with admin/admin"
-    echo "  3. Run 'ddev drush uli' for one-time login link"
-    echo ""
-    
-    
-    
+    if [ "$SETUP_FAILED" = "true" ]; then
+      # Overwrite WELCOME.txt so SSH login immediately shows the failure
+      {
+        echo "⚠  WORKSPACE SETUP INCOMPLETE"
+        echo "================================"
+        echo ""
+        echo "Setup encountered errors. Run this for details:"
+        echo "  cat $SETUP_LOG"
+        echo ""
+        echo "Errors:"
+        echo "$FAILURE_SUMMARY" | sed 's/^/  /'
+        echo ""
+        echo "Status file: cat $SETUP_STATUS"
+      } > ~/WELCOME.txt
+
+      echo ""
+      echo "=========================================="
+      echo "✗ SETUP FAILED"
+      echo "=========================================="
+      echo ""
+      echo "Errors:"
+      echo "$FAILURE_SUMMARY" | sed 's/^/  /'
+      echo ""
+      echo "Full log: cat $SETUP_LOG"
+      echo ""
+    else
+      echo "=== Setup Complete ==="
+      echo ""
+      echo "⏱  Timing: images=$${IMAGES_TIME}s  install=$${INSTALL_TIME}s  total=$${TOTAL_TIME}s"
+      echo ""
+      echo "📁 Drupal core ready at ~/drupal-core"
+      echo "📄 Welcome message saved to ~/WELCOME.txt"
+      echo ""
+      echo "Next steps:"
+      echo "  1. Click 'DDEV Web' app to access your site"
+      echo "  2. Log in with admin/admin"
+      echo "  3. Run 'ddev drush uli' for one-time login link"
+      echo ""
+    fi
+
     # Explicitly exit with success to prevent "Unhealthy" status
     exit 0
   EOT


### PR DESCRIPTION
## Summary

- **drupal-core template**: `ddev composer config allow-plugins true` before `composer update -W` so issue-fork packages like `symfony/runtime` don't block setup
- **drupal-core template**: On `SETUP_FAILED=true`, final banner now shows `✗ SETUP FAILED` with a collected list of error lines instead of `✨ Setup Complete!`; `WELCOME.txt` is overwritten with the failure notice so SSH login immediately surfaces the problem (fixes #92-adjacent UX gap)
- **operations guide**: Update Makefile examples to cover all three templates, add `push-all-templates` and `deploy-all` targets, add Auto-stop TTL section (`--default-ttl 2h`)
- **using-workspaces.md**: Add "Sharing and Collaboration" section — workspace sharing via UI and CLI, admin access, individual port sharing with visibility controls (fixes #80)

## Test plan

- [x] `make push-template-drupal-core` — template pushed successfully
- [x] Workspace created for issue #3453474 — composer allow-plugins fix unblocks setup
- [x] Failure summary: verified `✗ SETUP FAILED` banner appears at end of agent log on failure
- [x] Sharing docs: confirmed `coder sharing add` CLI command and Share button location match UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)