### PR TITLE
ci: add Terraform mock unit tests for all templates for #71 (Phase 2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Validate
         run: terraform validate
         working-directory: ${{ matrix.template }}
+      - name: Test
+        run: terraform test
+        working-directory: ${{ matrix.template }}
 
   fmt:
     name: Format Check

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,14 @@ validate: ## Validate all Terraform templates (requires terraform in PATH)
 fmt-check: ## Check Terraform formatting across all templates
 	terraform fmt -check -recursive
 
+.PHONY: test-templates
+test-templates: ## Run Terraform mock unit tests for all templates (requires terraform in PATH)
+	@for t in $(TEMPLATES); do \
+		echo "--- Testing $$t ---"; \
+		(cd $$t && terraform test) || exit 1; \
+	done
+	@echo "All template tests passed."
+
 .PHONY: clean
 clean: ## Remove local image
 	@echo "Removing local images..."

--- a/drupal-core/tests/validate.tftest.hcl
+++ b/drupal-core/tests/validate.tftest.hcl
@@ -1,0 +1,79 @@
+mock_provider "coder" {
+  mock_data "coder_workspace" {
+    defaults = {
+      start_count = 1
+      id          = "mock-workspace-id"
+      name        = "test-workspace"
+    }
+  }
+  mock_data "coder_workspace_owner" {
+    defaults = {
+      name = "testuser"
+    }
+  }
+  # vscode_extensions.value is jsondecode()d in locals; must be valid JSON
+  mock_data "coder_parameter" {
+    defaults = {
+      value = "[]"
+    }
+  }
+}
+
+mock_provider "docker" {}
+
+# cache_path has no default so must be supplied in every run block.
+# Any path works here — the mock docker provider does not validate host paths.
+
+run "plan_succeeds_with_defaults" {
+  command = plan
+  variables {
+    cache_path = "/tmp/mock-cache"
+  }
+}
+
+run "container_created_when_started" {
+  command = plan
+  variables {
+    cache_path = "/tmp/mock-cache"
+  }
+  assert {
+    condition     = length(docker_container.workspace) == 1
+    error_message = "docker_container.workspace must be created when start_count=1"
+  }
+}
+
+run "cpu_below_minimum" {
+  command = plan
+  variables {
+    cache_path = "/tmp/mock-cache"
+    cpu        = 0
+  }
+  expect_failures = [var.cpu]
+}
+
+run "cpu_above_maximum" {
+  command = plan
+  variables {
+    cache_path = "/tmp/mock-cache"
+    cpu        = 33
+  }
+  expect_failures = [var.cpu]
+}
+
+run "memory_below_minimum" {
+  command = plan
+  variables {
+    cache_path = "/tmp/mock-cache"
+    memory     = 1
+  }
+  expect_failures = [var.memory]
+}
+
+run "memory_above_maximum" {
+  command = plan
+  variables {
+    cache_path = "/tmp/mock-cache"
+    memory     = 129
+  }
+  expect_failures = [var.memory]
+}

--- a/freeform/tests/validate.tftest.hcl
+++ b/freeform/tests/validate.tftest.hcl
@@ -1,0 +1,85 @@
+mock_provider "coder" {
+  mock_data "coder_workspace" {
+    defaults = {
+      start_count = 1
+      id          = "mock-workspace-id"
+      name        = "test-workspace"
+    }
+  }
+  mock_data "coder_workspace_owner" {
+    defaults = {
+      name = "testuser"
+    }
+  }
+  # vscode_extensions.value is jsondecode()d in locals; must be valid JSON
+  mock_data "coder_parameter" {
+    defaults = {
+      value = "[]"
+    }
+  }
+}
+
+mock_provider "docker" {}
+
+run "plan_succeeds_with_defaults" {
+  command = plan
+}
+
+run "container_created_when_started" {
+  command = plan
+  assert {
+    condition     = length(docker_container.workspace) == 1
+    error_message = "docker_container.workspace must be created when start_count=1"
+  }
+}
+
+run "adminer_off_by_default" {
+  command = plan
+  assert {
+    condition     = length(coder_app.adminer) == 0
+    error_message = "coder_app.adminer must not be created when enable_adminer=false"
+  }
+}
+
+run "adminer_enabled" {
+  command = plan
+  variables {
+    enable_adminer = true
+  }
+  assert {
+    condition     = length(coder_app.adminer) == 1
+    error_message = "coder_app.adminer must be created when enable_adminer=true"
+  }
+}
+
+run "cpu_below_minimum" {
+  command = plan
+  variables {
+    cpu = 0
+  }
+  expect_failures = [var.cpu]
+}
+
+run "cpu_above_maximum" {
+  command = plan
+  variables {
+    cpu = 33
+  }
+  expect_failures = [var.cpu]
+}
+
+run "memory_below_minimum" {
+  command = plan
+  variables {
+    memory = 1
+  }
+  expect_failures = [var.memory]
+}
+
+run "memory_above_maximum" {
+  command = plan
+  variables {
+    memory = 129
+  }
+  expect_failures = [var.memory]
+}

--- a/user-defined-web/tests/validate.tftest.hcl
+++ b/user-defined-web/tests/validate.tftest.hcl
@@ -1,0 +1,66 @@
+mock_provider "coder" {
+  mock_data "coder_workspace" {
+    defaults = {
+      start_count = 1
+      id          = "mock-workspace-id"
+      name        = "test-workspace"
+    }
+  }
+  mock_data "coder_workspace_owner" {
+    defaults = {
+      name = "testuser"
+    }
+  }
+  # vscode_extensions.value is jsondecode()d in locals; must be valid JSON
+  mock_data "coder_parameter" {
+    defaults = {
+      value = "[]"
+    }
+  }
+}
+
+mock_provider "docker" {}
+
+run "plan_succeeds_with_defaults" {
+  command = plan
+}
+
+run "container_created_when_started" {
+  command = plan
+  assert {
+    condition     = length(docker_container.workspace) == 1
+    error_message = "docker_container.workspace must be created when start_count=1"
+  }
+}
+
+run "cpu_below_minimum" {
+  command = plan
+  variables {
+    cpu = 0
+  }
+  expect_failures = [var.cpu]
+}
+
+run "cpu_above_maximum" {
+  command = plan
+  variables {
+    cpu = 33
+  }
+  expect_failures = [var.cpu]
+}
+
+run "memory_below_minimum" {
+  command = plan
+  variables {
+    memory = 1
+  }
+  expect_failures = [var.memory]
+}
+
+run "memory_above_maximum" {
+  command = plan
+  variables {
+    memory = 129
+  }
+  expect_failures = [var.memory]
+}


### PR DESCRIPTION
## The Issue

Part of #71 (automated testing). Phase 2: Terraform mock unit tests that run with no live infrastructure.

## How This PR Solves The Issue

Adds a `tests/validate.tftest.hcl` file to each of the three templates using Terraform 1.7+ mock providers. The tests run entirely locally — no Coder server, no Docker, no credentials needed.

**Tests per template:**

| Test | user-defined-web | drupal-core | freeform |
|------|:---:|:---:|:---:|
| Plan succeeds with defaults | ✓ | ✓ | ✓ |
| `docker_container` created when `start_count=1` | ✓ | ✓ | ✓ |
| `cpu` below minimum (0) rejected | ✓ | ✓ | ✓ |
| `cpu` above maximum (33) rejected | ✓ | ✓ | ✓ |
| `memory` below minimum (1 GB) rejected | ✓ | ✓ | ✓ |
| `memory` above maximum (129 GB) rejected | ✓ | ✓ | ✓ |
| `enable_adminer` off by default | | | ✓ |
| `enable_adminer` creates `coder_app` | | | ✓ |

One non-obvious mock requirement: `vscode_extensions.value` is passed through `jsondecode()` in locals across all three templates, so the `coder_parameter` mock overrides the default random string with `"[]"` (a valid empty JSON array).

`drupal-core` requires `cache_path` in every run block since it has no default (tracked in #99 for removal).

Also adds `terraform test` step to the existing validate workflow matrix job and `make test-templates` for local use.

## Manual Testing Instructions

```bash
# Run all template tests locally (requires terraform in PATH)
make test-templates

# Or per-template
cd user-defined-web && terraform test
cd drupal-core && terraform test
cd freeform && terraform test
```

## Automated Testing Overview

This PR extends the workflow added in #100. The `terraform test` step runs after `terraform validate` in the same matrix job for each template. CI will run these 20 tests on every push and PR.

## Release/Deployment Notes

No impact on deployed templates or workspaces. CI-only change.
