### PR TITLE
ci: add staging push validation workflow for #71 (Phase 3)

### DIFF
--- a/.github/workflows/staging-push.yml
+++ b/.github/workflows/staging-push.yml
@@ -1,0 +1,83 @@
+name: Staging Push Validation
+
+# Pushes all templates to staging-coder.ddev.com with --activate=false to
+# verify the Coder provider accepts the HCL before any workspace is affected.
+#
+# Requires:
+#   Repository variable: TEST_CODER_URL         - https://staging-coder.ddev.com
+#   Repository secret:   OP_SERVICE_ACCOUNT_TOKEN - 1Password service account with read access
+#   1Password item:      op://test-secrets/TEST_CODER_SESSION_TOKEN/credential
+#                        (machine token for ci-bot user on test Coder instance)
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  push-staging:
+    name: Push to staging (${{ matrix.template }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - template: user-defined-web
+            extra_vars: ""
+          - template: drupal-core
+            # cache_path required until #99 (remove seed cache) lands;
+            # non-existent path is fine — only checked at workspace create time
+            extra_vars: "--variable cache_path=/tmp/ci-no-cache"
+          - template: freeform
+            extra_vars: ""
+      fail-fast: false
+    env:
+      VERSION_NAME: ci-${{ github.run_id }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load 1Password secrets
+        uses: 1password/load-secrets-action@v4
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          TEST_CODER_SESSION_TOKEN: "op://test-secrets/TEST_CODER_SESSION_TOKEN/credential"
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
+      - uses: coder/setup-action@v1
+        with:
+          access_url: ${{ vars.TEST_CODER_URL }}
+          coder_session_token: ${{ env.TEST_CODER_SESSION_TOKEN }}
+
+      - name: Copy VERSION into template directory
+        run: cp VERSION ${{ matrix.template }}/VERSION
+
+      - name: Push template (inactive)
+        run: |
+          coder templates push ${{ matrix.template }} \
+            --directory ${{ matrix.template }} \
+            --activate=false \
+            --name ${{ env.VERSION_NAME }} \
+            --yes \
+            --variable workspace_image_registry=index.docker.io/ddev/coder-ddev \
+            ${{ matrix.extra_vars }}
+
+      - name: Verify version exists
+        run: coder templates versions list ${{ matrix.template }} | grep ${{ env.VERSION_NAME }}
+
+      - name: Archive CI version
+        if: always()
+        run: coder templates versions archive ${{ matrix.template }} ${{ env.VERSION_NAME }} --yes || true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   validate:
@@ -18,6 +25,12 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~1.9"
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Init
         run: terraform init -backend=false -input=false
         working-directory: ${{ matrix.template }}
@@ -36,5 +49,11 @@ jobs:
       - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "~1.9"
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Check formatting
         run: terraform fmt -check -recursive

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ test-templates: ## Run Terraform mock unit tests for all templates (requires ter
 	done
 	@echo "All template tests passed."
 
+.PHONY: push-staging
+push-staging: ## Push all templates to staging-coder.ddev.com inactive (ACTIVATE=false); requires CODER_URL set to staging
+	$(MAKE) push-all-templates ACTIVATE=false
+
 .PHONY: clean
 clean: ## Remove local image
 	@echo "Removing local images..."


### PR DESCRIPTION
## The Issue

Part of #71 (automated testing). Phase 3: validate that all templates can be pushed to the live Coder API on staging without affecting any running workspaces.

## How This PR Solves The Issue

Adds `.github/workflows/staging-push.yml` which runs on every merge to `main` and on `workflow_dispatch`. For each of the three templates it:

1. Loads `TEST_CODER_SESSION_TOKEN` from 1Password (`op://test-secrets/TEST_CODER_SESSION_TOKEN/credential`) via the service account
2. Pushes the template to `staging-coder.ddev.com` with `--activate=false` and a unique version name (`ci-<run_id>`) — this validates the HCL against the live Coder provider, catching errors that `terraform validate` cannot
3. Verifies the version appears in `coder templates versions list`
4. Archives the CI version in an `if: always()` cleanup step

`drupal-core` passes `cache_path=/tmp/ci-no-cache` (required variable until #99 lands; non-existent path is fine since it is only checked at workspace-create time).

Also adds `make push-staging` as a local equivalent (`ACTIVATE=false` across all templates).

## Manual Testing Instructions

```bash
# Requires CODER_URL pointed at staging and a valid session token
make push-staging
```

Or trigger manually via the Actions tab → "Staging Push Validation" → Run workflow.

## Automated Testing Overview

Runs on every merge to `main`. Requires:
- Repository variable `TEST_CODER_URL` ✅
- Repository secret `OP_SERVICE_ACCOUNT_TOKEN` ✅
- 1Password item `op://test-secrets/TEST_CODER_SESSION_TOKEN/credential` ✅

## Release/Deployment Notes

No impact on production (code.ddev.com). All pushes are inactive and archived after verification.
