### PR TITLE
refactor: remove DB snapshot from seed cache, fixes #99

### DIFF
--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -691,9 +691,9 @@ This deploys three templates:
 
 ## Step 10: Set Up the Drupal Core Seed Cache (optional, highly recommended)
 
-The `drupal-core` template can provision a fully configured Drupal core development environment on new workspaces using a **seed cache** on the host. Without the cache, first-time workspace setup downloads a full git clone and all composer dependencies (~10-13 minutes). With the cache, the install phase drops to ~15 seconds, and total workspace startup is about a minute.
+The `drupal-core` template can provision a Drupal core development environment faster on new workspaces using a **seed cache** on the host. Without the cache, first-time workspace setup downloads a full git clone and all composer dependencies (~10-13 minutes). With the cache, the composer install phase is nearly instant; total workspace startup is 3-5 minutes (the remaining time is the Drupal site install, which always runs fresh).
 
-The cache is a standing DDEV project on the host that is periodically refreshed. New workspaces copy the git checkout, vendor directory, and a pre-built database snapshot from it.
+The cache is a standing DDEV project on the host that is periodically refreshed. New workspaces copy the git checkout and vendor directory from it. The database is always installed fresh via `ddev drush si` — this avoids schema-drift reliability problems with pre-built DB snapshots.
 
 ### Prerequisites
 
@@ -721,13 +721,6 @@ ddev composer create-project joachim-n/drupal-core-development-project --no-inte
 
 # Add Drush
 ddev composer require drush/drush
-
-# Install Drupal with the demo_umami profile
-ddev drush si -y demo_umami --account-pass=admin
-
-# Export the database snapshot used by new workspaces
-mkdir -p .tarballs
-ddev export-db --file=.tarballs/db.sql.gz
 ```
 
 After this runs, the seed directory contains:
@@ -738,12 +731,11 @@ After this runs, the seed directory contains:
 | `repos/drupal/` | Git clone of Drupal core |
 | `vendor/` | All Composer packages |
 | `web/` | Docroot (symlinked) |
-| `.tarballs/db.sql.gz` | Installed database snapshot |
 | `.ddev/` | Host DDEV config — **not** copied to workspaces |
 
 ### Install the hourly update timer
 
-The update script runs `composer update`, a fresh `drush si` (site install), and `export-db` to keep the cache current with Drupal HEAD. Install it as an hourly systemd timer:
+The update script runs `composer update` to keep the cache current with Drupal HEAD. Install it as an hourly systemd timer:
 
 ```bash
 REPO=~/workspace/coder-ddev   # adjust if your repo is elsewhere
@@ -801,15 +793,18 @@ make push-template-drupal-core DRUPAL_CACHE_PATH=/your/cache/path
 When a workspace starts for the first time:
 
 1. The startup script checks for a valid seed at `/home/coder-cache-seed` (the read-only bind mount of `cache_path`)
-2. **Cache hit:** `rsync` copies the project files (excluding `.ddev/`), `ddev composer install` ensures vendor is current, then `ddev import-db` loads the database dump (~15 seconds total)
+2. **Cache hit:** `rsync` copies the project files (excluding `.ddev/`), `ddev composer install` ensures vendor is current (near-instant with vendor already present), then `ddev drush si` installs Drupal fresh (~2-3 min)
 3. **Cache miss** (path absent or incomplete): falls back to full `ddev composer create-project` + `ddev drush si` — slower but always works
+
+The database is always installed fresh — there is no pre-built DB snapshot. This avoids schema-drift failures that occurred when the cached DB became stale relative to Drupal HEAD.
 
 Check workspace startup logs in the Coder dashboard or at `/tmp/drupal-setup.log` inside the workspace to confirm which path was taken.
 
 ### Troubleshooting
 
 **Cache not being used:**
-- Verify the seed directory exists and is populated: `ls $SEED_DIR/composer.json $SEED_DIR/.tarballs/db.sql.gz`
+
+- Verify the seed directory exists and is populated: `ls $SEED_DIR/composer.json $SEED_DIR/vendor`
 - Confirm `cache_path` in the deployed template matches your actual seed directory (check with `coder templates show drupal-core`)
 - Check the workspace startup log for the "Cache mount check" diagnostic block — it shows exactly which files were found or missing at the bind mount path
 - Look for "Cache hit" in the log; "No cache available" means the path is absent or the seed was never initialized

--- a/drupal-core/README.md
+++ b/drupal-core/README.md
@@ -20,11 +20,11 @@ Automated Coder workspace for Drupal core development using [joachim-n/drupal-co
 
 ## Initial Setup Time
 
-When a seed cache is available on the server (the default), first workspace creation takes approximately **15-30 seconds**:
+When a seed cache is available on the server (the default), first workspace creation takes approximately **3-5 minutes**:
 - rsync from seed cache: ~3s
 - git fetch: ~1s
 - composer install: ~2s
-- Database import: ~9s
+- Drupal site install (ddev drush si): ~2-3 min
 - DDEV start: ~15s
 
 Without a seed cache, first setup takes 10-15 minutes (full composer create + Drupal install).
@@ -166,7 +166,7 @@ coder create --template drupal-core my-workspace --parameter install_profile=sta
 ```
 Options: `demo_umami` (default), `minimal`, `standard`.
 
-Note: issue fork workspaces always run a full site install regardless of profile; `demo_umami` only uses the cached DB snapshot for standard workspaces.
+All workspaces run a full `ddev drush si` on first setup regardless of profile or whether an issue fork is specified.
 
 ### Add Custom Commands
 Create scripts in `~/.ddev/commands/host/` or `.ddev/commands/web/`

--- a/drupal-core/scripts/drupal-cache-updater.service
+++ b/drupal-core/scripts/drupal-cache-updater.service
@@ -16,8 +16,8 @@ WorkingDirectory=%h
 ExecStart=/usr/local/bin/update-drupal-cache
 StandardOutput=journal
 StandardError=journal
-# Allow up to 30 minutes for composer update + site install
-TimeoutStartSec=1800
+# Allow up to 20 minutes for composer update
+TimeoutStartSec=1200
 
 [Install]
 WantedBy=multi-user.target

--- a/drupal-core/scripts/update-drupal-cache
+++ b/drupal-core/scripts/update-drupal-cache
@@ -7,10 +7,10 @@
 # The seed cache is a pre-built drupal-core project containing:
 #   - repos/drupal/        Drupal core git clone
 #   - vendor/              Composer packages
-#   - .tarballs/db.sql.gz  Installed demo_umami database snapshot
 #
-# New workspaces copy from this cache (rsync + git fetch + ddev import-db)
-# instead of running a full composer create + site install, saving ~8-12 minutes.
+# New workspaces copy from this cache (rsync + git fetch + ddev composer install)
+# instead of downloading all packages from Packagist, saving several minutes.
+# The database is always installed fresh in each workspace via ddev drush si.
 #
 # Usage:
 #   ./update-drupal-cache [--seed-dir PATH]
@@ -79,15 +79,6 @@ ddev composer update --with-all-dependencies
 
 ddev composer require drush/drush
 
-# Fresh site install so the exported snapshot matches the updated codebase
-echo "Running site install..."
-ddev drush si -y demo_umami --account-pass=admin
-
-# Export the database snapshot for fast import into new workspaces
-echo "Exporting database snapshot..."
-mkdir -p .tarballs
-ddev export-db --file=.tarballs/db.sql.gz
-
 echo ""
 echo "=== Seed cache updated successfully ==="
 echo "Completed: $(date)"
@@ -95,5 +86,4 @@ echo ""
 echo "New workspaces will use this cache automatically."
 echo "Cache contents:"
 echo "  composer.json/lock: $(stat -c '%y' composer.lock 2>/dev/null | cut -d. -f1 || echo 'unknown')"
-echo "  db.sql.gz:          $(stat -c '%y' .tarballs/db.sql.gz 2>/dev/null | cut -d. -f1 || echo 'unknown')"
 echo "  Drupal HEAD:        $(git -C repos/drupal log -1 --format='%h %s' 2>/dev/null || echo 'unknown')"

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -871,8 +871,8 @@ WELCOME_STATIC
           update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project:dev-main\" ."
         fi
       else
-        log_setup "No cache available, running full composer create (this takes 5-10 minutes)..."
-        update_status "⏳ DDEV composer create: In progress (this takes 5-10 minutes)..."
+        log_setup "No cache available, running full composer create..."
+        update_status "⏳ DDEV composer create: In progress..."
 
         if ddev composer create joachim-n/drupal-core-development-project --no-interaction >> "$SETUP_LOG" 2>&1; then
           log_setup "✓ Drupal core development project created ($((SECONDS - _t))s)"
@@ -1072,13 +1072,9 @@ WELCOME_STATIC
         fi
       fi
 
-      # Step 6: Install or import Drupal database
-      # Fast path (DB cache import) is only used when:
-      #   - No issue fork (issue code may differ from cached DB)
-      #   - Install profile is demo_umami (cache was built with that profile)
-      #   - Cache tarball exists
+      # Step 6: Install Drupal database
 
-      # Compute site name for drush si (used when running a full install)
+      # Compute site name for drush si
       if [ -n "$ISSUE_FORK" ] && [ -n "$ISSUE_TITLE" ]; then
         SITE_NAME="#$${ISSUE_FORK}: $${ISSUE_TITLE}"
       elif [ -n "$ISSUE_FORK" ]; then
@@ -1090,31 +1086,12 @@ WELCOME_STATIC
       if ddev drush status 2>/dev/null | grep -q "Drupal bootstrap.*Successful"; then
         log_setup "✓ Drupal already installed"
         update_status "✓ Drupal install: Already present"
-      elif [ "$USING_ISSUE_FORK" = "false" ] && [ -f "$CACHE_SEED/.tarballs/db.sql.gz" ]; then
-        # Fast path: load seed DB for non-issue-fork workspaces when cache is available.
-        # The seed was built with demo_umami + current main, so the schema matches.
-        _t=$SECONDS
-        log_setup "Loading seed database (fast path)..."
-        update_status "⏳ Drupal install: Loading seed database..."
-        if gzip -dc "$CACHE_SEED/.tarballs/db.sql.gz" | ddev mysql >> "$SETUP_LOG" 2>&1; then
-          log_setup "✓ Seed database loaded ($((SECONDS - _t))s)"
-          log_setup ""
-          log_setup "   Admin Credentials:"
-          log_setup "      Username: admin"
-          log_setup "      Password: admin"
-          log_setup ""
-          update_status "✓ Drupal install: Loaded from seed"
-        else
-          log_setup "⚠ Seed DB load failed ($((SECONDS - _t))s), falling back to drush si..."
-          update_status "⚠ Drupal install: Seed load failed, running drush si..."
-          ddev drush si -y "$INSTALL_PROFILE" --account-pass=admin --site-name="$SITE_NAME" >> "$SETUP_LOG" 2>&1 || true
-        fi
       else
         _t=$SECONDS
         if [ "$USING_ISSUE_FORK" = "true" ]; then
-          log_setup "Installing Drupal with $INSTALL_PROFILE profile (issue fork: full install required)..."
+          log_setup "Installing Drupal with $INSTALL_PROFILE profile (issue fork)..."
         else
-          log_setup "Installing Drupal with $INSTALL_PROFILE profile (this will take 2-3 minutes)..."
+          log_setup "Installing Drupal with $INSTALL_PROFILE profile..."
         fi
         update_status "⏳ Drupal install: In progress..."
 


### PR DESCRIPTION
## Summary

* #99 

- Removes the pre-built database snapshot (`.tarballs/db.sql.gz`) from the drupal-core seed cache — this was the source of reliability failures due to schema drift between cache builds and workspace creation
- Workspaces now always run `ddev drush si` for a fresh Drupal install (~2-3 min); the composer/vendor and git objects cache is retained so package downloads are still avoided
- Simplifies `update-drupal-cache`: drops the `ddev drush si` and `ddev export-db` steps; the script now just does `composer update`
- Removes user-facing time estimates from startup log messages
- Updates `server-setup.md` and `drupal-core/README.md` to reflect the new behaviour

## Migration plan for existing servers

1. Delete the old DB snapshot from the cache directory on each server:
   ```
   rm -rf ~/cache/drupal-core-seed/.tarballs/
   ```
2. Deploy the updated template (`make push-template-drupal-core`)
3. Replace `update-drupal-cache` on each server from the updated repo
4. Run `update-drupal-cache` once to confirm the simplified flow works

Existing workspaces are unaffected — the DB fast-path only ran on first setup.

## Test plan

- [ ] Deploy updated template to staging
- [ ] Create a new plain main-branch workspace and confirm `ddev drush si` runs and Drupal installs cleanly
- [ ] Create an issue-fork workspace and confirm setup completes
- [ ] Run `update-drupal-cache` on staging server and confirm it completes without errors

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)