### PR TITLE
Auto-delete workspace host dirs on deletion, add cleanup script, fixes #56

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -175,9 +175,28 @@ jobs:
             bash /tmp/ci-ddev-test-${{ github.run_id }}.sh < /dev/null
           coder ssh ${{ env.WORKSPACE_NAME }} -- test -f /tmp/ci-ddev-success-${{ github.run_id }}
 
+      - name: Record expected host directory
+        run: |
+          OWNER=$(coder whoami --output json | jq -r '.username')
+          echo "HOST_DIR=/coder-workspaces/${OWNER}-${{ env.WORKSPACE_NAME }}" >> "$GITHUB_ENV"
+
       - name: Delete workspace
         if: always()
         run: coder delete ${{ env.WORKSPACE_NAME }} --yes || true
+
+      - name: Verify host directory removed
+        if: always()
+        run: |
+          if [[ -z "${HOST_DIR:-}" ]]; then
+            echo "HOST_DIR not set — workspace may not have been created, skipping"
+            exit 0
+          fi
+          if [[ -d "$HOST_DIR" ]]; then
+            echo "ERROR: Host directory was not removed by destroy provisioner: $HOST_DIR" >&2
+            ls -la "$HOST_DIR" >&2 || true
+            exit 1
+          fi
+          echo "OK: host directory removed: $HOST_DIR"
 
       - name: Archive CI template version
         if: always()

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Record expected host directory
         run: |
-          OWNER=$(coder whoami --output json | jq -r '.username')
+          OWNER=$(coder whoami --output json | jq -r 'if type == "array" then .[0].username else .username end')
           echo "HOST_DIR=/coder-workspaces/${OWNER}-${{ env.WORKSPACE_NAME }}" >> "$GITHUB_ENV"
 
       - name: Delete workspace

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -350,7 +350,7 @@ docker run --rm \
 
 ### Orphaned Workspace Cleanup
 
-When a workspace is deleted, Coder removes the container and its Docker named volume, but the host directory at `/coder-workspaces/<owner>-<workspace>` is left behind. Run the cleanup script periodically (e.g. monthly) to reclaim disk space.
+When a workspace is deleted, the destroy provisioner automatically removes the host directory at `/coder-workspaces/<owner>-<workspace>`. Directories can still be orphaned if the provisioner fails or for workspaces deleted before the provisioner was added. Run the cleanup script to reclaim disk space in those cases.
 
 ```bash
 # Dry run — shows what would be deleted without removing anything
@@ -360,7 +360,7 @@ When a workspace is deleted, Coder removes the container and its Docker named vo
 ./scripts/cleanup-deleted-workspaces.sh --force
 ```
 
-Run as your normal user (not root) — the script calls `sudo rm -rf` internally for directory removal, and uses `docker volume rm` (requires docker group membership).
+Run as your normal user (not root) — the script calls `sudo /usr/local/bin/coder-delete-workspace-dir` internally for directory removal, and uses `docker volume rm` (requires docker group membership).
 
 The script:
 

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -252,12 +252,9 @@ coder delete workspace1 workspace2 workspace3 --yes
 
 - Workspace container
 - `/var/lib/docker` Docker named volume (Docker daemon data for that workspace)
+- Host directory at `/coder-workspaces/<owner>-<workspace>` — via destroy-time provisioner in the template
 
-**Not** automatically removed:
-
-- The host directory at `/coder-workspaces/<owner>-<workspace>` (contains the user's files)
-
-Run `scripts/cleanup-deleted-workspaces.sh` periodically to remove these orphaned directories. See [Orphaned Workspace Cleanup](#orphaned-workspace-cleanup) below.
+If the provisioner doesn't run (e.g. Terraform error, or directories orphaned before this feature was added), use `scripts/cleanup-deleted-workspaces.sh`. See [Orphaned Workspace Cleanup](#orphaned-workspace-cleanup) below.
 
 ## Template Updates
 

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -360,8 +360,10 @@ When a workspace is deleted, Coder removes the container and its Docker named vo
 ./scripts/cleanup-deleted-workspaces.sh
 
 # Actually delete orphaned directories and Docker volumes
-sudo ./scripts/cleanup-deleted-workspaces.sh --force
+./scripts/cleanup-deleted-workspaces.sh --force
 ```
+
+Run as your normal user (not root) — the script calls `sudo rm -rf` internally for directory removal, and uses `docker volume rm` (requires docker group membership).
 
 The script:
 
@@ -370,7 +372,7 @@ The script:
 - Reports sizes before deleting
 - Refuses to delete anything if the Coder CLI returns no workspaces (guards against misconfigured auth)
 
-**Prerequisites:** `coder` CLI must be authenticated as an admin (so `coder list --all` returns all users' workspaces). `docker` must be available on the host.
+**Prerequisites:** `coder` CLI authenticated as an admin; user in the `docker` group; `sudo` access for directory removal.
 
 ### Template Versioning
 

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -248,11 +248,16 @@ coder delete my-workspace --yes
 coder delete workspace1 workspace2 workspace3 --yes
 ```
 
-**Note:** Deleting a workspace removes:
+**Deleting a workspace removes:**
+
 - Workspace container
-- `/home/coder` volume (host directory)
-- `/var/lib/docker` volume (Docker daemon data)
-- All DDEV containers and volumes inside the workspace
+- `/var/lib/docker` Docker named volume (Docker daemon data for that workspace)
+
+**Not** automatically removed:
+
+- The host directory at `/coder-workspaces/<owner>-<workspace>` (contains the user's files)
+
+Run `scripts/cleanup-deleted-workspaces.sh` periodically to remove these orphaned directories. See [Orphaned Workspace Cleanup](#orphaned-workspace-cleanup) below.
 
 ## Template Updates
 
@@ -345,6 +350,27 @@ docker run --rm \
   ubuntu:24.04 \
   tar -xzf /backup/docker-volume-backup.tar.gz -C /target
 ```
+
+### Orphaned Workspace Cleanup
+
+When a workspace is deleted, Coder removes the container and its Docker named volume, but the host directory at `/coder-workspaces/<owner>-<workspace>` is left behind. Run the cleanup script periodically (e.g. monthly) to reclaim disk space.
+
+```bash
+# Dry run — shows what would be deleted without removing anything
+./scripts/cleanup-deleted-workspaces.sh
+
+# Actually delete orphaned directories and Docker volumes
+sudo ./scripts/cleanup-deleted-workspaces.sh --force
+```
+
+The script:
+
+- Queries `coder list --all` to get the current list of active workspaces
+- Compares against directories in `/coder-workspaces/` and Docker volumes named `coder-*-dind-cache`
+- Reports sizes before deleting
+- Refuses to delete anything if the Coder CLI returns no workspaces (guards against misconfigured auth)
+
+**Prerequisites:** `coder` CLI must be authenticated as an admin (so `coder list --all` returns all users' workspaces). `docker` must be available on the host.
 
 ### Template Versioning
 

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -582,7 +582,7 @@ The Coder systemd service sets `NoNewPrivileges`, which blocks sudo. Override th
 ```bash
 # Allow the coder service to use sudo (needed for workspace directory cleanup)
 sudo mkdir -p /etc/systemd/system/coder.service.d/
-printf '[Service]\nNoNewPrivileges=no\nCapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE\n' \
+printf '[Service]\nNoNewPrivileges=no\nCapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE CAP_DAC_OVERRIDE\n' \
   | sudo tee /etc/systemd/system/coder.service.d/allow-privileges.conf
 sudo systemctl daemon-reload && sudo systemctl restart coder
 

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -580,7 +580,8 @@ When a workspace is deleted, a Terraform destroy-time provisioner runs `rm -rf` 
 The solution is a default ACL on `/coder-workspaces/` that gives the `coder` user `rwx` on every new workspace directory created there. In Linux, deleting a file requires write permission on its *parent directory*, not on the file itself — so this is sufficient for `rm -rf` with no privilege escalation.
 
 ```bash
-sudo apt-get install -y acl
+# acl is installed by default on Ubuntu 24.04; this is a no-op if already present
+sudo apt-get update && sudo apt-get install -y acl
 sudo setfacl -m u:coder:rwx /coder-workspaces
 sudo setfacl -d -m u:coder:rwx /coder-workspaces
 # Verify

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -582,7 +582,7 @@ The Coder systemd service sets `NoNewPrivileges`, which blocks sudo. Override th
 ```bash
 # Allow the coder service to use sudo (needed for workspace directory cleanup)
 sudo mkdir -p /etc/systemd/system/coder.service.d/
-printf '[Service]\nNoNewPrivileges=no\nCapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID\n' \
+printf '[Service]\nNoNewPrivileges=no\nCapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE\n' \
   | sudo tee /etc/systemd/system/coder.service.d/allow-privileges.conf
 sudo systemctl daemon-reload && sudo systemctl restart coder
 
@@ -590,7 +590,7 @@ sudo systemctl daemon-reload && sudo systemctl restart coder
 sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
 
 # Grant coder user sudo access to only that script
-echo 'coder ALL=(ALL) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
+echo 'coder ALL=(#1000) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
   | sudo tee /etc/sudoers.d/coder-workspace-cleanup
 sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
 sudo visudo -c

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -575,22 +575,30 @@ journalctl -u coder -f
 
 ### Allow Coder to delete workspace directories
 
-When a workspace is deleted, a Terraform destroy-time provisioner runs `rm -rf` to clean up the workspace host directory. The Coder service runs as the `coder` system user (UID 999), but workspace files are owned by UID 1000. Sudo is not an option — the Coder systemd service sets `NoNewPrivileges`, which blocks sudo entirely.
+When a workspace is deleted, a Terraform destroy-time provisioner calls a wrapper script to remove the workspace's host directory. The Coder service runs as the `coder` system user (UID 999), but workspace files are owned by UID 1000.
 
-The solution is a default ACL on `/coder-workspaces/` that gives the `coder` user `rwx` on every new workspace directory created there. In Linux, deleting a file requires write permission on its *parent directory*, not on the file itself — so this is sufficient for `rm -rf` with no privilege escalation.
+The Coder systemd service sets `NoNewPrivileges`, which blocks sudo. Override that, install the wrapper, and configure sudoers:
 
 ```bash
-# acl is installed by default on Ubuntu 24.04; this is a no-op if already present
-sudo apt-get update && sudo apt-get install -y acl
-sudo setfacl -m u:coder:rwx /coder-workspaces
-sudo setfacl -d -m u:coder:rwx /coder-workspaces
-# Verify
-getfacl /coder-workspaces
+# Allow the coder service to use sudo (needed for workspace directory cleanup)
+sudo mkdir -p /etc/systemd/system/coder.service.d/
+echo -e '[Service]\nNoNewPrivileges=no' \
+  | sudo tee /etc/systemd/system/coder.service.d/allow-privileges.conf
+sudo systemctl daemon-reload && sudo systemctl restart coder
+
+# Install the wrapper script
+sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
+
+# Grant coder user sudo access to only that script
+echo 'coder ALL=(ALL) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
+  | sudo tee /etc/sudoers.d/coder-workspace-cleanup
+sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
+sudo visudo -c
 ```
 
-The `-d` flag sets the *default* ACL, which new subdirectories inherit automatically. Directories created by Docker for each workspace will inherit `rwx` for the `coder` user, and files created inside those directories will inherit it recursively from there.
+The wrapper validates that the argument matches exactly `/coder-workspaces/<alphanumeric-name>` before deleting, preventing path traversal even though sudo is in play.
 
-Without this, workspace deletion will log permission errors and leave the directory behind (recoverable with `scripts/cleanup-deleted-workspaces.sh`).
+Without this setup, workspace deletion will log permission errors and leave the directory behind (recoverable with `scripts/cleanup-deleted-workspaces.sh`).
 
 ### First-run admin setup
 

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -573,6 +573,19 @@ View logs:
 journalctl -u coder -f
 ```
 
+### Allow Coder to delete workspace directories
+
+The Coder service runs as the `coder` system user. When a workspace is deleted, a Terraform destroy-time provisioner runs `sudo rm -rf` to clean up the workspace's host directory under `/coder-workspaces/`. Grant the `coder` user passwordless sudo for that operation:
+
+```bash
+echo 'coder ALL=(ALL) NOPASSWD: /usr/bin/rm -rf -- /coder-workspaces/*' \
+  | sudo tee /etc/sudoers.d/coder-workspace-cleanup
+sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
+sudo visudo -c  # verify the file is valid
+```
+
+Without this, workspace deletion will log permission errors and leave the directory behind (it falls back to `scripts/cleanup-deleted-workspaces.sh`).
+
 ### First-run admin setup
 
 Navigate to `https://coder.example.com` (your hostname) and create the initial admin user.

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -575,7 +575,7 @@ journalctl -u coder -f
 
 ### Allow Coder to delete workspace directories
 
-When a workspace is deleted, a Terraform destroy-time provisioner calls a wrapper script to remove the workspace's host directory. The Coder service runs as the `coder` system user (UID 999), but workspace files are owned by UID 1000.
+When a workspace is deleted, a Terraform destroy-time provisioner calls a wrapper script to remove the workspace's host directory. The Coder service runs as the `coder` system user (UID 999) and needs root to delete entries from `/coder-workspaces/` (owned by root).
 
 The Coder systemd service sets `NoNewPrivileges`, which blocks sudo. Override that, install the wrapper, and configure sudoers:
 
@@ -589,14 +589,14 @@ sudo systemctl daemon-reload && sudo systemctl restart coder
 # Install the wrapper script
 sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
 
-# Grant coder user sudo access to only that script
-echo 'coder ALL=(#1000) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
+# Grant coder user sudo access to only that script (runs as root)
+echo 'coder ALL=(root) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
   | sudo tee /etc/sudoers.d/coder-workspace-cleanup
 sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
 sudo visudo -c
 ```
 
-The wrapper validates that the argument matches exactly `/coder-workspaces/<alphanumeric-name>` before deleting, preventing path traversal even though sudo is in play.
+The wrapper validates that the argument matches exactly `/coder-workspaces/<alphanumeric-name>` before deleting, preventing path traversal even though the script runs as root.
 
 Without this setup, workspace deletion will log permission errors and leave the directory behind (recoverable with `scripts/cleanup-deleted-workspaces.sh`).
 

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -582,7 +582,7 @@ The Coder systemd service sets `NoNewPrivileges`, which blocks sudo. Override th
 ```bash
 # Allow the coder service to use sudo (needed for workspace directory cleanup)
 sudo mkdir -p /etc/systemd/system/coder.service.d/
-echo -e '[Service]\nNoNewPrivileges=no' \
+printf '[Service]\nNoNewPrivileges=no\nCapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID\n' \
   | sudo tee /etc/systemd/system/coder.service.d/allow-privileges.conf
 sudo systemctl daemon-reload && sudo systemctl restart coder
 

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -575,16 +575,24 @@ journalctl -u coder -f
 
 ### Allow Coder to delete workspace directories
 
-The Coder service runs as the `coder` system user. When a workspace is deleted, a Terraform destroy-time provisioner runs `sudo rm -rf` to clean up the workspace's host directory under `/coder-workspaces/`. Grant the `coder` user passwordless sudo for that operation:
+When a workspace is deleted, a Terraform destroy-time provisioner calls a wrapper script to remove the workspace's host directory. The Coder service (running as the `coder` system user) needs passwordless sudo access to that specific script.
+
+Install the wrapper and configure sudoers:
 
 ```bash
-echo 'coder ALL=(ALL) NOPASSWD: /usr/bin/rm -rf -- /coder-workspaces/*' \
+# Install the wrapper script
+sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
+
+# Grant coder user sudo access to only that script
+echo 'coder ALL=(ALL) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
   | sudo tee /etc/sudoers.d/coder-workspace-cleanup
 sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
-sudo visudo -c  # verify the file is valid
+sudo visudo -c
 ```
 
-Without this, workspace deletion will log permission errors and leave the directory behind (it falls back to `scripts/cleanup-deleted-workspaces.sh`).
+The wrapper validates that the argument matches exactly `/coder-workspaces/<alphanumeric-name>` before deleting, preventing path traversal. Granting sudo for a bare `rm -rf` with a glob would allow path traversal attacks if the `coder` process were ever compromised.
+
+Without this setup, workspace deletion will log permission errors and leave the directory behind (recoverable with `scripts/cleanup-deleted-workspaces.sh`).
 
 ### First-run admin setup
 

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -575,24 +575,21 @@ journalctl -u coder -f
 
 ### Allow Coder to delete workspace directories
 
-When a workspace is deleted, a Terraform destroy-time provisioner calls a wrapper script to remove the workspace's host directory. The Coder service (running as the `coder` system user) needs passwordless sudo access to that specific script.
+When a workspace is deleted, a Terraform destroy-time provisioner runs `rm -rf` to clean up the workspace host directory. The Coder service runs as the `coder` system user (UID 999), but workspace files are owned by UID 1000. Sudo is not an option — the Coder systemd service sets `NoNewPrivileges`, which blocks sudo entirely.
 
-Install the wrapper and configure sudoers:
+The solution is a default ACL on `/coder-workspaces/` that gives the `coder` user `rwx` on every new workspace directory created there. In Linux, deleting a file requires write permission on its *parent directory*, not on the file itself — so this is sufficient for `rm -rf` with no privilege escalation.
 
 ```bash
-# Install the wrapper script
-sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
-
-# Grant coder user sudo access to only that script
-echo 'coder ALL=(ALL) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir' \
-  | sudo tee /etc/sudoers.d/coder-workspace-cleanup
-sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
-sudo visudo -c
+sudo apt-get install -y acl
+sudo setfacl -m u:coder:rwx /coder-workspaces
+sudo setfacl -d -m u:coder:rwx /coder-workspaces
+# Verify
+getfacl /coder-workspaces
 ```
 
-The wrapper validates that the argument matches exactly `/coder-workspaces/<alphanumeric-name>` before deleting, preventing path traversal. Granting sudo for a bare `rm -rf` with a glob would allow path traversal attacks if the `coder` process were ever compromised.
+The `-d` flag sets the *default* ACL, which new subdirectories inherit automatically. Directories created by Docker for each workspace will inherit `rwx` for the `coder` user, and files created inside those directories will inherit it recursively from there.
 
-Without this setup, workspace deletion will log permission errors and leave the directory behind (recoverable with `scripts/cleanup-deleted-workspaces.sh`).
+Without this, workspace deletion will log permission errors and leave the directory behind (recoverable with `scripts/cleanup-deleted-workspaces.sh`).
 
 ### First-run admin setup
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1666,7 +1666,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo rm -rf -- '${self.triggers.host_path}'"
   }
 }
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1666,7 +1666,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1666,7 +1666,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1666,7 +1666,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1666,7 +1666,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1666,7 +1666,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "rm -rf -- '${self.triggers.host_path}'"
   }
 }
 

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -1644,9 +1644,7 @@ resource "docker_container" "workspace" {
   # Command to keep container running
   command = ["sh", "-c", coder_agent.main.init_script]
 
-  # Ensure container is destroyed (stopped) BEFORE workspace_cleanup runs (rm -rf) through reverse dependency
-
-
+  depends_on = [null_resource.workspace_cleanup]
 
   # Restart policy
   restart = "unless-stopped"
@@ -1661,9 +1659,16 @@ resource "docker_container" "workspace" {
   privileged = false
 }
 
-# Cleanup ddev resources when workspace is destroyed
-# NOTE: Destroy provisioner temporarily disabled due to Terraform limitations
-# TODO: Implement cleanup via alternative method (e.g., Coder lifecycle hooks or external script)
+resource "null_resource" "workspace_cleanup" {
+  triggers = {
+    host_path = "/coder-workspaces/${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -rf -- '${self.triggers.host_path}'"
+  }
+}
 
 resource "coder_metadata" "workspace_info" {
   resource_id = docker_container.workspace[0].id

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -565,7 +565,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -565,7 +565,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "rm -rf -- '${self.triggers.host_path}'"
   }
 }
 

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -565,7 +565,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -565,7 +565,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -554,6 +554,19 @@ resource "docker_container" "workspace" {
   ]
 
   privileged = false
+
+  depends_on = [null_resource.workspace_cleanup]
+}
+
+resource "null_resource" "workspace_cleanup" {
+  triggers = {
+    host_path = "/coder-workspaces/${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -rf -- '${self.triggers.host_path}'"
+  }
 }
 
 resource "coder_metadata" "workspace_info" {

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -565,7 +565,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo rm -rf -- '${self.triggers.host_path}'"
   }
 }
 

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -565,7 +565,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 # Remove host directories and Docker volumes left behind by deleted Coder workspaces.
 #
+# New workspaces clean up automatically on deletion via the null_resource destroy
+# provisioner in each template. This script handles directories that were orphaned
+# before that provisioner existed, or in any case where the provisioner didn't run.
+#
 # By default runs in dry-run mode (prints what would be deleted).
 # Pass --force to actually delete.
 #
-# Requires: coder CLI (authenticated), docker, jq
+# Requires: coder CLI (authenticated as admin), docker (in docker group), sudo access
 #
 # Usage:
-#   ./scripts/cleanup-deleted-workspaces.sh           # dry run
-#   ./scripts/cleanup-deleted-workspaces.sh --force   # delete orphaned data
+#   ./scripts/cleanup-deleted-workspaces.sh                          # dry run
+#   ./scripts/cleanup-deleted-workspaces.sh --force                  # delete orphaned data
+#   WORKSPACES_DIR=/custom/path ./scripts/cleanup-deleted-workspaces.sh  # override base dir
 
 set -euo pipefail
 
-WORKSPACES_DIR="/coder-workspaces"
+WORKSPACES_DIR="${WORKSPACES_DIR:-/coder-workspaces}"
 FORCE=false
 
 for arg in "$@"; do

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -77,7 +77,7 @@ else
     size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
     echo "  $dir  ($size)"
     if [[ "$FORCE" == true ]]; then
-      sudo rm -rf -- "$dir"
+      sudo /usr/local/bin/coder-delete-workspace-dir "$dir"
       echo "  -> deleted"
     fi
   done

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -77,7 +77,7 @@ else
     size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
     echo "  $dir  ($size)"
     if [[ "$FORCE" == true ]]; then
-      sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir "$dir"
+      sudo /usr/local/bin/coder-delete-workspace-dir "$dir"
       echo "  -> deleted"
     fi
   done

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -72,7 +72,7 @@ else
     size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
     echo "  $dir  ($size)"
     if [[ "$FORCE" == true ]]; then
-      rm -rf "$dir"
+      sudo rm -rf "$dir"
       echo "  -> deleted"
     fi
   done

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -77,7 +77,7 @@ else
     size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
     echo "  $dir  ($size)"
     if [[ "$FORCE" == true ]]; then
-      sudo rm -rf "$dir"
+      sudo /usr/local/bin/coder-delete-workspace-dir "$dir"
       echo "  -> deleted"
     fi
   done

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -77,7 +77,7 @@ else
     size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
     echo "  $dir  ($size)"
     if [[ "$FORCE" == true ]]; then
-      sudo /usr/local/bin/coder-delete-workspace-dir "$dir"
+      sudo rm -rf -- "$dir"
       echo "  -> deleted"
     fi
   done

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Remove host directories and Docker volumes left behind by deleted Coder workspaces.
+#
+# By default runs in dry-run mode (prints what would be deleted).
+# Pass --force to actually delete.
+#
+# Requires: coder CLI (authenticated), docker, jq
+#
+# Usage:
+#   ./scripts/cleanup-deleted-workspaces.sh           # dry run
+#   ./scripts/cleanup-deleted-workspaces.sh --force   # delete orphaned data
+
+set -euo pipefail
+
+WORKSPACES_DIR="/coder-workspaces"
+FORCE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=true ;;
+    --help|-h)
+      sed -n '2,10p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$FORCE" == false ]]; then
+  echo "DRY RUN — pass --force to actually delete"
+  echo
+fi
+
+# Build a set of active workspace directory names: "<owner>-<workspace>"
+if ! active_json=$(coder list --all --output json 2>/dev/null); then
+  echo "ERROR: 'coder list --all --output json' failed. Is the coder CLI authenticated?" >&2
+  exit 1
+fi
+
+declare -A active_dirs
+while IFS= read -r entry; do
+  active_dirs["$entry"]=1
+done < <(echo "$active_json" | jq -r '.[] | "\(.owner_name)-\(.name)"')
+
+if [[ ${#active_dirs[@]} -eq 0 ]]; then
+  echo "WARNING: No active workspaces found. Refusing to delete anything to avoid wiping data if coder CLI is misconfigured." >&2
+  exit 1
+fi
+
+echo "Active workspaces: ${!active_dirs[*]}"
+echo
+
+# --- Host directories ---
+orphan_dirs=()
+if [[ -d "$WORKSPACES_DIR" ]]; then
+  while IFS= read -r dir; do
+    base=$(basename "$dir")
+    if [[ -z "${active_dirs[$base]+_}" ]]; then
+      orphan_dirs+=("$dir")
+    fi
+  done < <(find "$WORKSPACES_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+fi
+
+if [[ ${#orphan_dirs[@]} -eq 0 ]]; then
+  echo "No orphaned host directories found in $WORKSPACES_DIR"
+else
+  echo "Orphaned host directories:"
+  for dir in "${orphan_dirs[@]}"; do
+    size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
+    echo "  $dir  ($size)"
+    if [[ "$FORCE" == true ]]; then
+      rm -rf "$dir"
+      echo "  -> deleted"
+    fi
+  done
+fi
+
+echo
+
+# --- Docker volumes ---
+orphan_volumes=()
+while IFS= read -r vol; do
+  # Volume names look like: coder-<owner>-<workspace>-dind-cache
+  if [[ "$vol" =~ ^coder-(.+)-dind-cache$ ]]; then
+    owner_workspace="${BASH_REMATCH[1]}"
+    if [[ -z "${active_dirs[$owner_workspace]+_}" ]]; then
+      orphan_volumes+=("$vol")
+    fi
+  fi
+done < <(docker volume ls --format '{{.Name}}' | grep '^coder-' | sort)
+
+if [[ ${#orphan_volumes[@]} -eq 0 ]]; then
+  echo "No orphaned Docker volumes found"
+else
+  echo "Orphaned Docker volumes:"
+  for vol in "${orphan_volumes[@]}"; do
+    size=$(docker system df -v 2>/dev/null | awk -v v="$vol" '$1==v {print $3}' || echo "?")
+    echo "  $vol  ($size)"
+    if [[ "$FORCE" == true ]]; then
+      docker volume rm "$vol"
+      echo "  -> deleted"
+    fi
+  done
+fi
+
+echo
+if [[ "$FORCE" == false && ( ${#orphan_dirs[@]} -gt 0 || ${#orphan_volumes[@]} -gt 0 ) ]]; then
+  echo "Re-run with --force to delete the items listed above."
+fi

--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -77,7 +77,7 @@ else
     size=$(du -sh "$dir" 2>/dev/null | cut -f1 || echo "?")
     echo "  $dir  ($size)"
     if [[ "$FORCE" == true ]]; then
-      sudo /usr/local/bin/coder-delete-workspace-dir "$dir"
+      sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir "$dir"
       echo "  -> deleted"
     fi
   done

--- a/scripts/coder-delete-workspace-dir.sh
+++ b/scripts/coder-delete-workspace-dir.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Safely delete a single workspace host directory.
+# Intended to be called via sudo by the coder service user at workspace deletion time.
+# Validates the path strictly before deleting to prevent path traversal attacks.
+#
+# Usage: sudo /usr/local/bin/coder-delete-workspace-dir <path>
+#   e.g. sudo /usr/local/bin/coder-delete-workspace-dir /coder-workspaces/rfay-myworkspace
+#
+# Install: sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
+
+set -euo pipefail
+
+path="${1:-}"
+
+if [[ -z "$path" ]]; then
+  echo "Usage: $0 <workspace-dir>" >&2
+  exit 1
+fi
+
+# Require exactly /coder-workspaces/<name> where <name> is alphanumeric + hyphens/underscores.
+# No slashes, no .., no empty name. This prevents path traversal.
+if [[ ! "$path" =~ ^/coder-workspaces/[a-zA-Z0-9][a-zA-Z0-9_-]+$ ]]; then
+  echo "Refusing to delete invalid path: $path" >&2
+  exit 1
+fi
+
+[[ -d "$path" ]] || exit 0
+
+# Files may be owned by a different UID than the process running rm.
+# Reset permissions on the directory so rm can remove everything.
+chmod -R u+rwX "$path" 2>/dev/null || true
+
+exec rm -rf -- "$path"

--- a/scripts/coder-delete-workspace-dir.sh
+++ b/scripts/coder-delete-workspace-dir.sh
@@ -26,8 +26,4 @@ fi
 
 [[ -d "$path" ]] || exit 0
 
-# Files may be owned by a different UID than the process running rm.
-# Reset permissions on the directory so rm can remove everything.
-chmod -R u+rwX "$path" 2>/dev/null || true
-
 exec rm -rf -- "$path"

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -743,7 +743,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -721,9 +721,7 @@ resource "docker_container" "workspace" {
   # Command to keep container running
   command = ["sh", "-c", coder_agent.main.init_script]
 
-  # Ensure container is destroyed (stopped) BEFORE workspace_cleanup runs (rm -rf) through reverse dependency
-
-
+  depends_on = [null_resource.workspace_cleanup]
 
   # Restart policy
   restart = "unless-stopped"
@@ -738,9 +736,16 @@ resource "docker_container" "workspace" {
   privileged = false
 }
 
-# Cleanup ddev resources when workspace is destroyed
-# NOTE: Destroy provisioner temporarily disabled due to Terraform limitations
-# TODO: Implement cleanup via alternative method (e.g., Coder lifecycle hooks or external script)
+resource "null_resource" "workspace_cleanup" {
+  triggers = {
+    host_path = "/coder-workspaces/${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}"
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = "rm -rf -- '${self.triggers.host_path}'"
+  }
+}
 
 resource "coder_metadata" "workspace_info" {
   resource_id = docker_container.workspace[0].id

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -743,7 +743,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -743,7 +743,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -743,7 +743,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "rm -rf -- '${self.triggers.host_path}'"
   }
 }
 

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -743,7 +743,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "sudo -u '#1000' /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
+    command = "sudo /usr/local/bin/coder-delete-workspace-dir '${self.triggers.host_path}'"
   }
 }
 

--- a/user-defined-web/template.tf
+++ b/user-defined-web/template.tf
@@ -743,7 +743,7 @@ resource "null_resource" "workspace_cleanup" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf -- '${self.triggers.host_path}'"
+    command = "sudo rm -rf -- '${self.triggers.host_path}'"
   }
 }
 


### PR DESCRIPTION
Fixes #56

## Summary

- Adds a Terraform destroy-time provisioner to all three templates that removes the workspace host directory (`/coder-workspaces/<owner>-<workspace>`) when a workspace is deleted
- Adds `scripts/coder-delete-workspace-dir.sh` — a validated wrapper script that strictly accepts only paths matching `/coder-workspaces/<alphanumeric-name>` before calling `rm -rf`, preventing path traversal
- Adds `scripts/cleanup-deleted-workspaces.sh` — a manual dry-run-by-default script for cleaning up directories and Docker volumes orphaned before the automatic provisioner existed
- Documents required server-side setup in `docs/admin/server-setup.md`: systemd capability override (`NoNewPrivileges=no`, `CAP_DAC_OVERRIDE` + friends), sudoers entry, and wrapper install
- Adds integration test assertion that the host directory is removed after workspace deletion

## Server-side setup required

On each Coder host before this works:

```bash
sudo mkdir -p /etc/systemd/system/coder.service.d/
printf '[Service]\nNoNewPrivileges=no\nCapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_AUDIT_WRITE CAP_DAC_OVERRIDE\n'   | sudo tee /etc/systemd/system/coder.service.d/allow-privileges.conf
sudo systemctl daemon-reload && sudo systemctl restart coder
sudo install -m 755 scripts/coder-delete-workspace-dir.sh /usr/local/bin/coder-delete-workspace-dir
echo 'coder ALL=(root) NOPASSWD: /usr/local/bin/coder-delete-workspace-dir'   | sudo tee /etc/sudoers.d/coder-workspace-cleanup
sudo chmod 0440 /etc/sudoers.d/coder-workspace-cleanup
sudo visudo -c
```

Already applied to staging-coder.ddev.com and coder.ddev.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)