### PR TITLE
docs: add ufw firewall setup and disk space cleanup instructions, fixes #107

### DIFF
--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -348,6 +348,47 @@ docker run --rm \
   tar -xzf /backup/docker-volume-backup.tar.gz -C /target
 ```
 
+### Disk Space Cleanup
+
+When disk space is running low, reclaim it in this order:
+
+#### 1. List all workspaces (including other users')
+
+```bash
+coder list -a
+```
+
+#### 2. Delete unused workspaces
+
+Stopped or dormant workspaces that are no longer needed can be deleted. This removes the workspace container, Docker volume, and host directory:
+
+```bash
+# Delete a single workspace
+coder delete <owner>/<workspace-name> --yes
+
+# Delete multiple workspaces at once
+coder delete <owner>/<workspace1> <owner>/<workspace2> --yes
+```
+
+Check the Coder dashboard for "Last used" times to identify dormant workspaces before deleting.
+
+#### 3. Prune the Docker BuildKit cache
+
+BuildKit caches can accumulate across workspace image builds:
+
+```bash
+docker buildx prune -f
+```
+
+#### 4. Check remaining disk usage
+
+```bash
+df -h /data /coder-workspaces
+docker system df
+```
+
+---
+
 ### Orphaned Workspace Cleanup
 
 When a workspace is deleted, the destroy provisioner automatically removes the host directory at `/coder-workspaces/<owner>-<workspace>`. Directories can still be orphaned if the provisioner fails or for workspaces deleted before the provisioner was added. Run the cleanup script to reclaim disk space in those cases.

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -194,6 +194,38 @@ docker --version
 sudo systemctl enable --now docker
 ```
 
+### Configure the firewall
+
+Enable UFW and open the ports needed by Coder and the registry mirror. Port 5665 is for the Icinga2 monitoring agent and should be restricted to the monitoring server's IP:
+
+```bash
+sudo ufw allow 22
+sudo ufw allow 80
+sudo ufw allow 443
+sudo ufw allow 5000
+sudo ufw allow from 45.79.99.253 to any port 5665/tcp
+sudo ufw enable
+sudo ufw status
+```
+
+Expected output:
+
+```text
+Status: active
+
+To                         Action      From
+--                         ------      ----
+443                        ALLOW       Anywhere
+80                         ALLOW       Anywhere
+22                         ALLOW       Anywhere
+5000                       ALLOW       Anywhere
+5665/tcp                   ALLOW       45.79.99.253
+443 (v6)                   ALLOW       Anywhere (v6)
+80 (v6)                    ALLOW       Anywhere (v6)
+22 (v6)                    ALLOW       Anywhere (v6)
+5000 (v6)                  ALLOW       Anywhere (v6)
+```
+
 ---
 
 ## Step 3: Set Up the Registry Mirror


### PR DESCRIPTION
## Summary

- Add UFW firewall configuration section to server-setup.md (end of Step 2) with required ports for Coder (80/443), SSH (22), registry mirror (5000), and Icinga2 monitoring agent (5665 from monitoring server IP only)
- Add disk space cleanup section to operations-guide.md covering `coder list -a`, workspace deletion, `docker buildx prune -f`, and checking remaining disk usage

## Test plan

- [ ] Review ufw commands and expected `ufw status` output match the described setup
- [ ] Review disk cleanup steps are accurate and complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)