### PR TITLE
ci: add manual push-image workflow with 1Password and tmate support

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -4,12 +4,20 @@ name: Push Image
 # machines don't need cross-compilation. Triggered manually only.
 #
 # Required repository secrets:
-#   PUSH_SERVICE_ACCOUNT_TOKEN - 1Password service account token
+#   OP_SERVICE_ACCOUNT_TOKEN - 1Password service account token
 # Required repository variables:
 #   DOCKERHUB_USERNAME - Docker Hub username
+# Required 1Password item:
+#   op://push-secrets/DOCKERHUB_TOKEN/credential
 
 on:
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate set "debug_enabled"'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -25,13 +33,20 @@ jobs:
         id: version
         run: echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
 
-      - name: Load 1password secret(s)
+      - name: Load 1Password secrets
         uses: 1password/load-secrets-action@v4
         with:
           export-env: true
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: "${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}"
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -4,7 +4,7 @@ name: Push Image
 # machines don't need cross-compilation. Triggered manually only.
 #
 # Required repository secrets:
-#   OP_SERVICE_ACCOUNT_TOKEN - 1Password service account token
+#   PUSH_SERVICE_ACCOUNT_TOKEN - 1Password service account with push-secrets vault access
 # Required repository variables:
 #   DOCKERHUB_USERNAME - Docker Hub username
 # Required 1Password item:
@@ -38,7 +38,7 @@ jobs:
         with:
           export-env: true
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PUSH_SERVICE_ACCOUNT_TOKEN }}
           DOCKERHUB_TOKEN: "op://push-secrets/DOCKERHUB_TOKEN/credential"
 
       - name: Setup tmate session


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/push-image.yml` triggered by `workflow_dispatch` only (replaces the old `build-image.yml` that fired on every push to main)
- Loads `DOCKERHUB_TOKEN` from 1Password `push-secrets` vault via `PUSH_SERVICE_ACCOUNT_TOKEN`
- Adds `debug_enabled` input with tmate session support, matching other workflows in this repo
- Updates all action versions to current: `checkout@v6`, `setup-buildx-action@v4`, `login-action@v4`, `build-push-action@v7`

## Test plan

- [ ] Trigger via **Actions → Push Image → Run workflow** and verify image pushes to Docker Hub with correct version tag and `latest`
- [ ] Optionally: trigger with `debug_enabled: true` to verify tmate session opens
- [ ] Trigger via CLI: `gh workflow run push-image.yml --ref <branch>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)