### PR TITLE
fix: replace obsolete ddev composer create with create-project, drop :dev-main pin, fixes #79

### DIFF
--- a/drupal-core/README.md
+++ b/drupal-core/README.md
@@ -138,7 +138,7 @@ cd ~/drupal-core
 # Adjust project-type to match your version: drupal10, drupal11, or drupal12
 ddev config --project-type=drupal12 --docroot=web
 ddev start
-ddev composer create joachim-n/drupal-core-development-project
+ddev composer create-project joachim-n/drupal-core-development-project .
 ddev composer require drush/drush
 ddev drush si -y demo_umami --account-pass=admin
 ```

--- a/drupal-core/scripts/test-issue-branches.sh
+++ b/drupal-core/scripts/test-issue-branches.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-issue-branches.sh — Test joachim-n/drupal-core-development-project:dev-main
+# test-issue-branches.sh — Test joachim-n/drupal-core-development-project
 # against known Drupal core issue branches to validate composer fix logic.
 #
 # Usage:
@@ -84,11 +84,11 @@ for PAIR in "${TESTS[@]}"; do
     log "DDEV project already configured"
   fi
 
-  # --- composer create-project using dev-main ---
+  # --- composer create-project ---
   if [ ! -f "composer.json" ]; then
-    log "Running composer create-project (dev-main)..."
+    log "Running composer create-project..."
     ddev composer create-project --no-install --no-interaction \
-      "joachim-n/drupal-core-development-project:dev-main" . 2>&1 | tail -20
+      "joachim-n/drupal-core-development-project" . 2>&1 | tail -20
   else
     log "composer.json already present — skipping create-project"
   fi
@@ -143,7 +143,7 @@ for PAIR in "${TESTS[@]}"; do
   fi
 
   # --- Apply composer.json fixes ---
-  # joachim-n/drupal-core-development-project:dev-main uses "*" for all drupal/* constraints.
+  # joachim-n/drupal-core-development-project uses "*" for all drupal/* constraints.
   # Issue fork branches present as dev-ISSUEBRANCH; drupal/core-recommended's N.x-dev
   # requirement won't match that, so Fix 1+2 adds an inline alias for issue forks only.
   # Named release branches (10.6.x, 11.x) present at 10.6.x-dev / 11.x-dev — the "*"

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -817,7 +817,7 @@ WELCOME_STATIC
       else
         log_setup "✗ Failed to seed from cache ($((SECONDS - _t))s), falling back to full setup..."
         update_status "⚠ Cache seed failed, running full setup..."
-        ddev composer create joachim-n/drupal-core-development-project --no-interaction >> "$SETUP_LOG" 2>&1
+        ddev composer create-project --no-interaction joachim-n/drupal-core-development-project . >> "$SETUP_LOG" 2>&1
         DRUPAL_SETUP_NEEDED=true
       fi
     else
@@ -829,7 +829,7 @@ WELCOME_STATIC
         log_setup "Issue fork: creating project structure (dependencies installed after branch checkout)..."
         update_status "⏳ DDEV composer create-project: In progress..."
 
-        if ddev composer create-project --no-install --no-interaction "joachim-n/drupal-core-development-project:dev-main" . >> "$SETUP_LOG" 2>&1; then
+        if ddev composer create-project --no-install --no-interaction "joachim-n/drupal-core-development-project" . >> "$SETUP_LOG" 2>&1; then
           log_setup "✓ Project structure created ($((SECONDS - _t))s)"
           update_status "✓ DDEV composer create-project: Success"
           DRUPAL_SETUP_NEEDED=true
@@ -845,14 +845,14 @@ WELCOME_STATIC
           update_status "✗ DDEV composer create-project: Failed"
           update_status ""
           update_status "Manual recovery:"
-          update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project:dev-main\" ."
+          update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project\" ."
         fi
       elif [ "$NEEDS_NONMAIN_CHECKOUT" = "true" ]; then
         # Non-main version (10.x/11.x) without cache: create project structure then checkout branch.
         # Must use --no-install (like issue fork) so vendor is resolved for the correct branch.
         log_setup "Creating project structure for Drupal $DRUPAL_VERSION ($DRUPAL_BRANCH), no cache available..."
         update_status "⏳ DDEV composer create-project: In progress..."
-        if ddev composer create-project --no-install --no-interaction "joachim-n/drupal-core-development-project:dev-main" . >> "$SETUP_LOG" 2>&1; then
+        if ddev composer create-project --no-install --no-interaction "joachim-n/drupal-core-development-project" . >> "$SETUP_LOG" 2>&1; then
           log_setup "✓ Project structure created ($((SECONDS - _t))s)"
           update_status "✓ DDEV composer create-project: Success"
           DRUPAL_SETUP_NEEDED=true
@@ -868,23 +868,23 @@ WELCOME_STATIC
           update_status "✗ DDEV composer create-project: Failed"
           update_status ""
           update_status "Manual recovery:"
-          update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project:dev-main\" ."
+          update_status "  cd $DRUPAL_DIR && ddev composer create-project --no-install \"joachim-n/drupal-core-development-project\" ."
         fi
       else
         log_setup "No cache available, running full composer create..."
         update_status "⏳ DDEV composer create: In progress..."
 
-        if ddev composer create joachim-n/drupal-core-development-project --no-interaction >> "$SETUP_LOG" 2>&1; then
+        if ddev composer create-project --no-interaction joachim-n/drupal-core-development-project . >> "$SETUP_LOG" 2>&1; then
           log_setup "✓ Drupal core development project created ($((SECONDS - _t))s)"
-          update_status "✓ DDEV composer create: Success"
+          update_status "✓ DDEV composer create-project: Success"
           DRUPAL_SETUP_NEEDED=true
         else
           log_setup "✗ Failed to create Drupal core development project ($((SECONDS - _t))s)"
           log_setup "Check $SETUP_LOG for details"
-          update_status "✗ DDEV composer create: Failed"
+          update_status "✗ DDEV composer create-project: Failed"
           update_status ""
           update_status "Manual recovery:"
-          update_status "  cd $DRUPAL_DIR && ddev composer create joachim-n/drupal-core-development-project"
+          update_status "  cd $DRUPAL_DIR && ddev composer create-project joachim-n/drupal-core-development-project ."
         fi
       fi
     fi
@@ -951,7 +951,7 @@ WELCOME_STATIC
           fi
 
           # Apply composer.json fixes so ddev composer update resolves correctly.
-          # joachim-n/drupal-core-development-project:dev-main uses "*" for all drupal/*
+          # joachim-n/drupal-core-development-project uses "*" for all drupal/*
           # root constraints and includes repos/drupal/composer/Plugin/* as a glob path repo
           # (so RecipeUnpack is covered). However, transitive constraints BETWEEN path repo
           # issue fork branches need Fix 1+2: e.g. drupal/core-recommended requires drupal/core


### PR DESCRIPTION
## Summary

- Replace all `ddev composer create` calls with `ddev composer create-project` (the shorthand is obsolete)
- Remove `:dev-main` version pin from `joachim-n/drupal-core-development-project`; latest stable is picked up automatically (currently 2.0.2)
- Version 2.0.2 drops drush from its own `composer.json`, but drush is already added explicitly in Step 5 of the startup script so no functional change is needed
- Update comments and status messages to match

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)