### PR TITLE
fix: post-merge contrib followup — enable check and picker version inference

### DIFF
--- a/docs/drupal-issue.html
+++ b/docs/drupal-issue.html
@@ -575,10 +575,12 @@
           if (issueResp.ok) {
             const issue = await issueResp.json();
             if (issue.title) title = issue.title;
-            // field_issue_version e.g. "10.6.x-dev" or "11.x-dev" → extract major version
+            // field_issue_version is "10.6.x-dev", "11.x-dev", "12.x-dev", or "main"
+            // "main" means the current development branch (D12+); no leading digit → use 12.
             const ver = issue.field_issue_version || '';
             const m = ver.match(/^(\d+)\./);
             if (m) drupalMajor = m[1];
+            else if (ver === 'main' || ver.startsWith('12')) drupalMajor = '12';
           }
         } catch (_) { /* title/version stay as fallback */ }
 

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -702,20 +702,22 @@ COMPOSE_EOF
           fi
 
           if [ "$SETUP_FAILED" = "false" ]; then
-            # Enable the module or theme
+            # Enable the module or theme.
+            # ddev drush en can exit non-zero even when the module ends up enabled
+            # (e.g. a post-install hook in another module throws a fatal), so verify
+            # via pm:list rather than trusting the exit code.
             log_setup "Enabling $PROJECT_NAME ($PROJECT_TYPE)..."
             if [ "$PROJECT_TYPE" = "theme" ]; then
-              if ddev drush theme:enable "$PROJECT_NAME" -y >> "$SETUP_LOG" 2>&1; then
-                log_setup "✓ $PROJECT_NAME enabled"
-              else
-                log_setup "⚠ Warning: could not enable theme $PROJECT_NAME (may need manual enable)"
-              fi
+              ddev drush theme:enable "$PROJECT_NAME" -y >> "$SETUP_LOG" 2>&1 || true
             else
-              if ddev drush en "$PROJECT_NAME" -y >> "$SETUP_LOG" 2>&1; then
-                log_setup "✓ $PROJECT_NAME enabled"
-              else
-                log_setup "⚠ Warning: could not enable module $PROJECT_NAME (may need manual enable)"
-              fi
+              ddev drush en "$PROJECT_NAME" -y >> "$SETUP_LOG" 2>&1 || true
+            fi
+            if ddev drush pm:list --status=enabled --format=list 2>/dev/null | grep -qw "$PROJECT_NAME"; then
+              log_setup "✓ $PROJECT_NAME enabled"
+              update_status "✓ $PROJECT_NAME: Enabled"
+            else
+              log_setup "⚠ Warning: $PROJECT_NAME not found in enabled modules list"
+              update_status "⚠ $PROJECT_NAME: Not enabled (check /tmp/drupal-setup.log)"
             fi
           fi
         fi


### PR DESCRIPTION
## Summary

Two bugs found during post-merge testing of #122 (drupal-contrib template):

- **Module enable check used drush exit code**: `ddev drush en` exits non-zero when a post-install hook in another module throws a PHP fatal (e.g. `update_storage_clear()` missing in the installed Drupal version), even though the target module is fully enabled. The template was logging a false warning and the CI grep was failing. Now we run `drush en` with `|| true` and verify actual enablement via `pm:list --status=enabled`.

- **Picker chose D11 for `field_issue_version = "main"` issues**: The core issue picker's regex `^(\d+)\.` does not match the string `"main"`, so `drupalMajor` was never updated and defaulted to `"11"`. Both issues 3564112 and 3585397 have `field_issue_version = "main"` (the Drupal 12+ development branch). The CI shell inference already handled this correctly via `|| echo "12"`; this aligns the picker JavaScript with that behaviour.

## Why CI didn't catch the picker bug

The CI tests template execution given a `drupal_version` parameter — it never runs picker JavaScript. The shell-based version inference in `drupal-integration-test.yml` correctly mapped `"main"` → `12` all along; only the picker was broken. There is currently no test coverage for `docs/` JavaScript.

## Test plan

- [ ] Open the core issue picker, paste a URL for issue 3564112 or 3585397 — Drupal version should auto-select **12**, not 11
- [ ] Create a workspace from the picker with a `field_issue_version = "main"` issue — workspace should start with D12/PHP 8.5
- [ ] Verify CI drupal-contrib plain jobs pass (module enabled check now uses `pm:list` not drush exit code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)