### PR TITLE
fix: handle field_issue_version='main' in contrib picker

### DIFF
--- a/docs/drupal-contrib-picker.html
+++ b/docs/drupal-contrib-picker.html
@@ -683,6 +683,7 @@
               const ver = issue.field_issue_version || '';
               const verM = ver.match(/^(\d+)\./);
               if (verM) drupalMajor = verM[1];
+              else if (ver === 'main' || ver.startsWith('12')) drupalMajor = '12';
             }
           }
         } catch (_) { /* title/version stay as fallback */ }


### PR DESCRIPTION
## Summary

PR #123 fixed \`drupal-issue.html\` but missed the same bug in \`drupal-contrib-picker.html\`. When a core issue URL is pasted into the contrib picker, it takes the same version-inference code path. \`field_issue_version = "main"\` (the Drupal 12+ development branch) does not match \`^(\d+)\.\`, so \`drupalMajor\` stayed at the form default of \`"11"\`.

## Test plan

- [ ] Open \`start.coder.ddev.com/drupal-contrib-picker\`, paste a core issue URL e.g. \`drupal.org/project/drupal/issues/3564112\` — Drupal version should auto-select **12**, not 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)