### PR TITLE
feat: deprecate user-defined-web template, fixes #114

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,9 @@ TEMPLATE_VARS_freeform         := --variable workspace_image_registry=index.dock
 
 # Per-template display metadata set via `coder templates edit` after push
 # (coder templates push only supports --name, not --description)
-TEMPLATE_EDIT_user-defined-web := --display-name "DDEV Web Workspace"
+TEMPLATE_EDIT_user-defined-web := --display-name "[DEPRECATED] DDEV Web Workspace" \
+                                   --description "Deprecated: use the freeform template instead. Existing workspaces continue to work." \
+                                   --deprecated "Deprecated: use the freeform template instead. Existing workspaces continue to work."
 TEMPLATE_EDIT_drupal-core      := --display-name "Drupal Core Development" \
                                    --description "Drupal core dev environment: full DDEV stack, core clone, Umami demo site. Ready in about a minute."
 TEMPLATE_EDIT_drupal-contrib   := --display-name "Drupal Contrib Development" \

--- a/user-defined-web/README.md
+++ b/user-defined-web/README.md
@@ -1,5 +1,7 @@
 # User-Defined Web DDEV Template
 
+> **Deprecated:** This template is no longer recommended. Use the **`freeform`** template instead — it provides the same functionality with a cleaner setup. Existing workspaces continue to work, but new workspaces should be created from `freeform`.
+
 General-purpose DDEV workspace for developing any project type supported by DDEV (PHP, WordPress, Laravel, Drupal, Magento, and more). Provides a full Docker environment via Sysbox with VS Code for Web and DDEV pre-configured.
 
 ## Features


### PR DESCRIPTION
## Summary

- Marks `user-defined-web` as deprecated in the Makefile: sets `[DEPRECATED]` display name, description, and `--deprecated` flag (the flag is a no-op on OSS Coder but will work automatically if the server ever moves to enterprise)
- Adds deprecation notice to `user-defined-web/README.md` pointing users to the `freeform` template
- Existing workspaces are unaffected; only new workspace creation is discouraged

## Deployment plan

The display name `[DEPRECATED] DDEV Web Workspace` and description are already live on coder.ddev.com (set via API). staging-coder.ddev.com has the `--deprecated` flag applied from testing.

To make the metadata durable and consistent with this commit on both servers, run a full template push. This also updates the VERSION for the 25 active users on coder.ddev.com who are on an outdated template version:

```bash
# staging
CODER_URL=https://staging-coder.ddev.com make push-template-user-defined-web

# production
CODER_URL=https://coder.ddev.com make push-template-user-defined-web
```

Note: `--deprecated` is silently ignored by OSS Coder (it is gated behind `FeatureAccessControl` in the enterprise build). The display name and description are the visible deprecation signal on OSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)