### PR TITLE
fix(ci): drupal integration tests and drupal-contrib validate missing from CI

### DIFF
--- a/.github/workflows/drupal-contrib-integration-test.yml
+++ b/.github/workflows/drupal-contrib-integration-test.yml
@@ -5,7 +5,7 @@ name: Drupal Contrib Integration Tests
 #
 # Two jobs:
 #   contrib-plain       — matrix of known modules on D11, runs on every
-#                         push to drupal-contrib/** and nightly
+#                         push to main and nightly
 #   contrib-issue-fork  — single workspace using a real drupal.org contrib issue
 #                         fork, runs nightly only
 #
@@ -35,8 +35,6 @@ on:
     - cron: '0 5 * * *'
   push:
     branches: [main]
-    paths:
-      - 'drupal-contrib/**'
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/drupal-integration-test.yml
+++ b/.github/workflows/drupal-integration-test.yml
@@ -5,7 +5,7 @@ name: Drupal Integration Tests
 #
 # Two jobs:
 #   drupal-plain       — matrix of D11 and D12, no issue fork, runs on every
-#                        push to drupal-core/** and nightly
+#                        push to main and nightly
 #   drupal-issue-fork  — single workspace using a real drupal.org issue fork,
 #                        runs nightly only
 #
@@ -40,8 +40,6 @@ on:
     - cron: '0 4 * * *'
   push:
     branches: [main]
-    paths:
-      - 'drupal-core/**'
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        template: [user-defined-web, drupal-core, freeform]
+        template: [user-defined-web, drupal-core, drupal-contrib, freeform]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- `drupal-contrib/tests/validate.tftest.hcl` exists but `drupal-contrib` was missing from the `validate.yml` matrix — `terraform validate` and `terraform test` never ran for it in CI
- `drupal-integration-test.yml` and `drupal-contrib-integration-test.yml` had `paths:` filters on their push trigger, so integration tests only fired when their respective template dirs changed — merges touching `image/`, `scripts/`, `.github/`, or `VERSION` silently skipped them. PRs already had no path filter, so this was an asymmetry.

## Test plan

- [ ] Verify the new `Validate (drupal-contrib)` job appears and passes in CI on this PR
- [ ] Verify `Drupal Integration Tests` and `Drupal Contrib Integration Tests` appear in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)