### PR TITLE
fix: remove deprecated user-defined-web card, improve freeform description

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -304,17 +304,8 @@
       <div class="template-cards">
         <div class="template-card">
           <div class="info">
-            <h3>DDEV Web Workspace</h3>
-            <p>Bring your own project — any PHP, Node, or Python project with DDEV</p>
-          </div>
-          <a class="btn" href="https://coder.ddev.com/templates/coder/user-defined-web/workspace?mode=manual">
-            <img src="https://coder.ddev.com/open-in-coder.svg" alt="Open in Coder">
-          </a>
-        </div>
-        <div class="template-card">
-          <div class="info">
             <h3>DDEV Freeform</h3>
-            <p>Single DDEV project with Traefik routing for stable public subdomains</p>
+            <p>Run multiple DDEV projects in one workspace, each accessible via its own subdomain through ddev-router</p>
           </div>
           <a class="btn" href="https://coder.ddev.com/templates/coder/freeform/workspace?mode=manual">
             <img src="https://coder.ddev.com/open-in-coder.svg" alt="Open in Coder">


### PR DESCRIPTION
## Summary

- Removes the "DDEV Web Workspace" template card from `docs/index.html` — it linked to the now-deprecated `user-defined-web` template
- Corrects the DDEV Freeform description from the misleading "Single DDEV project with Traefik routing…" to accurately describe its multi-project capability via ddev-router

## Test plan

- [ ] Verify start.coder.ddev.com no longer shows "DDEV Web Workspace" card
- [ ] Verify DDEV Freeform description is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)