### PR TITLE
feat(ci): disable self-hosted jobs, restore -gh parallelism

### DIFF
--- a/.github/workflows/drupal-contrib-integration-test.yml
+++ b/.github/workflows/drupal-contrib-integration-test.yml
@@ -47,7 +47,9 @@ on:
 jobs:
   contrib-plain:
     name: Contrib ${{ matrix.project }} D${{ matrix.drupal_version }} (plain)
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+    # Disabled: self-hosted sysbox runner; use contrib-plain-gh instead.
+    # To re-enable: restore `if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}`
+    if: false
     runs-on: [self-hosted, sysbox]
     strategy:
       matrix:
@@ -204,7 +206,9 @@ jobs:
 
   contrib-issue-fork:
     name: Contrib ${{ vars.CONTRIB_TEST_PROJECT || 'token' }} issue fork
-    if: ${{ vars.CONTRIB_TEST_ISSUE_FORK != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner) }}
+    # Disabled: self-hosted sysbox runner; use contrib-issue-fork-gh instead.
+    # To re-enable: restore `if: ${{ vars.CONTRIB_TEST_ISSUE_FORK != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner) }}`
+    if: false
     runs-on: [self-hosted, sysbox]
     defaults:
       run:
@@ -392,7 +396,6 @@ jobs:
           - project: pathauto
             drupal_version: "11"
       fail-fast: false
-      max-parallel: 1
     defaults:
       run:
         shell: bash -euo pipefail {0}

--- a/.github/workflows/drupal-integration-test.yml
+++ b/.github/workflows/drupal-integration-test.yml
@@ -52,7 +52,9 @@ on:
 jobs:
   drupal-plain:
     name: Drupal ${{ matrix.drupal_version }} (plain)
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+    # Disabled: self-hosted sysbox runner; use drupal-plain-gh instead.
+    # To re-enable: restore `if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}`
+    if: false
     runs-on: [self-hosted, sysbox]
     strategy:
       matrix:
@@ -201,7 +203,6 @@ jobs:
       matrix:
         drupal_version: ["12", "11"]
       fail-fast: false
-      max-parallel: 1
     defaults:
       run:
         shell: bash -euo pipefail {0}
@@ -268,7 +269,9 @@ jobs:
 
   drupal-issue-fork:
     name: Drupal issue fork ${{ vars.DRUPAL_TEST_ISSUE_FORK || '3585397' }}
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+    # Disabled: self-hosted sysbox runner; use drupal-issue-fork-gh instead.
+    # To re-enable: restore `if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}`
+    if: false
     runs-on: [self-hosted, sysbox]
     defaults:
       run:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -68,7 +68,9 @@ concurrency:
 jobs:
   integration-test:
     name: Integration test (${{ matrix.template }})
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+    # Disabled: self-hosted sysbox runner; use integration-test-gh instead.
+    # To re-enable: restore `if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}`
+    if: false
     runs-on: [self-hosted, sysbox]
     strategy:
       matrix:
@@ -303,7 +305,6 @@ jobs:
             extra_params: ""
             app_slug: ""
       fail-fast: false
-      max-parallel: 1
     defaults:
       run:
         shell: bash -euo pipefail {0}


### PR DESCRIPTION
## Summary

- Sets `if: false` on the five self-hosted sysbox jobs so they no longer queue while the GitHub-hosted `-gh` equivalents prove out
- The original `if:` condition is preserved in a comment directly above each disabled job for a one-line revert if needed
- Removes `max-parallel: 1` from the `-gh` matrix jobs — only needed to avoid rate-limit collisions when both sets ran concurrently

## To re-enable self-hosted jobs

In each workflow, swap `if: false` back to the commented original condition.

## Test plan

- [ ] Only `-gh` jobs appear in CI (no self-hosted jobs queued)
- [ ] `-gh` matrix jobs run in parallel
- [ ] All `-gh` jobs pass

Generated with [Claude Code](https://claude.com/claude-code)