### PR TITLE
docs(admin): configure containerd data root to /data [skip ci]

### DIFF
--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -189,8 +189,16 @@ sudo tee /etc/docker/daemon.json > /dev/null <<'EOF'
 }
 EOF
 
+# Configure containerd to use /data as well.
+# containerd runs as a separate daemon from Docker and has its own data root
+# (default: /var/lib/containerd). Without this, /var fills up with image snapshots.
+sudo mkdir -p /etc/containerd
+containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
+sudo sed -i 's|^root = .*|root = "/data/containerd"|' /etc/containerd/config.toml
+
 # Verify
 docker --version
+sudo systemctl enable --now containerd
 sudo systemctl enable --now docker
 ```
 

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -857,6 +857,20 @@ du -sh /coder-workspaces/* | sort -h
 # Delete unused workspaces
 ```
 
+**/var partition full (containerd not in /data):**
+
+containerd runs as a daemon separate from Docker and has its own data root (`/var/lib/containerd` by default). If the server was set up without configuring containerd's root, image snapshots accumulate in `/var` rather than `/data`. Fix:
+
+```bash
+sudo systemctl stop docker containerd
+sudo mv /var/lib/containerd /data/containerd
+sudo sed -i 's|^root = .*|root = "/data/containerd"|' /etc/containerd/config.toml
+sudo systemctl start containerd && sudo systemctl start docker
+docker ps  # verify healthy
+```
+
+New server setups should configure containerd's root during initial setup — see `server-setup.md`.
+
 ## Getting Help
 
 ### Information to Collect


### PR DESCRIPTION
## Summary

- `server-setup.md`: add containerd root configuration during Docker install so new servers store containerd snapshots in `/data/containerd` rather than `/var/lib/containerd`
- `troubleshooting.md`: document the fix for existing servers where `/var` fills up due to containerd not being configured to use `/data`

## Background

containerd runs as a separate daemon from Docker with its own data root (`/var/lib/containerd` by default). Docker's `data-root` was already pointing at `/data/docker`, but containerd's root was never configured — causing `/var` to fill up with image snapshots on staging.

## Test plan

- [ ] Verify `server-setup.md` containerd config block generates a valid `config.toml` with `root = "/data/containerd"` on a fresh install
- [ ] Verify troubleshooting steps restore a healthy `docker ps` after moving `/var/lib/containerd` to `/data/containerd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)