### PR TITLE
docs(drupal-core): fix seed cache description and service setup instructions

### DIFF
--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -857,7 +857,7 @@ This deploys three templates:
 
 The `drupal-core` template can provision workspaces faster using a **seed cache** on the host. The cache is a plain git clone of drupal/drupal. New workspaces pass it as a `--reference` hint to `git clone`, reusing local git objects and avoiding several hundred MB of network transfer. Composer install still runs fresh inside each workspace.
 
-The database is always installed fresh via `ddev drush si`.
+The seed cache is just a simple git checkout — no DDEV project, no database, no vendor directory, no composer files.
 
 ### One-time initial setup
 
@@ -957,7 +957,7 @@ make push-template-drupal-core DRUPAL_CACHE_PATH=/your/cache/path
 When a workspace starts for the first time:
 
 1. The startup script checks for `.git` at `/home/coder-cache-seed` (the read-only bind mount of `cache_path`)
-2. **Cache hit:** `git clone --reference` reuses local git objects for the initial clone (fast), then `ddev composer install` runs fresh inside the container
+2. **Cache hit:** `git clone --reference` reuses local git objects for the initial clone (fast), then `composer install` runs fresh inside the container
 3. **Cache miss** (path absent or no `.git` at root): `git clone` runs without a reference — slower but always works
 
 Check workspace startup logs in the Coder dashboard or at `/tmp/drupal-setup.log` inside the workspace to confirm which path was taken.

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -920,7 +920,7 @@ Run these steps on each server:
 SEED_DIR=~/cache/drupal-core-seed
 REPO=~/workspace/coder-ddev
 
-# 1. Stop the old DDEV seed project
+# 1. Stop the old DDEV seed project (only needed if it was still running)
 cd "$SEED_DIR" && ddev stop --remove-data 2>/dev/null || true
 
 # 2. Move the git clone to the seed root, remove everything else
@@ -928,14 +928,22 @@ mv "$SEED_DIR/repos/drupal" /tmp/drupal-git-tmp
 rm -rf "$SEED_DIR"
 mv /tmp/drupal-git-tmp "$SEED_DIR"
 
-# 3. Install the updated update script and service
+# 3. Install the updated script, service, and timer
 sudo install -m 755 $REPO/drupal-core/scripts/update-drupal-cache \
   /usr/local/bin/update-drupal-cache
 sudo install -m 644 $REPO/drupal-core/scripts/drupal-cache-updater.service \
   /etc/systemd/system/
-sudo systemctl daemon-reload
+sudo install -m 644 $REPO/drupal-core/scripts/drupal-cache-updater.timer \
+  /etc/systemd/system/
 
-# 4. Verify it works
+# 4. Set the correct user in the service file (YOURUSER is a placeholder)
+sudo sed -i "s/User=YOURUSER/User=$(whoami)/" /etc/systemd/system/drupal-cache-updater.service
+
+# 5. Enable and start the timer
+sudo systemctl daemon-reload
+sudo systemctl enable --now drupal-cache-updater.timer
+
+# 6. Verify it works
 sudo systemctl start drupal-cache-updater.service
 journalctl -u drupal-cache-updater.service --no-pager | tail -10
 ```

--- a/drupal-core/scripts/drupal-cache-updater.service
+++ b/drupal-core/scripts/drupal-cache-updater.service
@@ -6,7 +6,7 @@ Type=oneshot
 # Must run as the user who owns the seed cache directory — NOT root.
 # Change User= to the account that owns the cache (e.g. your server's admin user).
 User=YOURUSER
-WorkingDirectory=%h
+WorkingDirectory=/tmp
 # The script is installed to /usr/local/bin/ (see docs/admin/server-setup.md).
 # The script defaults to ~/cache/drupal-core-seed (relative to the User= above).
 # Pass --seed-dir only if your seed directory differs from that default.

--- a/drupal-core/scripts/update-drupal-cache
+++ b/drupal-core/scripts/update-drupal-cache
@@ -20,6 +20,9 @@
 # Note: When run via the systemd timer, the seed directory is taken from the default
 # or from the ExecStart line in drupal-cache-updater.service — edit that file to pass
 # --seed-dir if your seed directory differs from the default.
+#
+# IMPORTANT: This script must be reinstalled to /usr/local/bin/ after any changes:
+#   sudo install -m 755 drupal-core/scripts/update-drupal-cache /usr/local/bin/update-drupal-cache
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Fixes inaccurate and incomplete seed cache documentation introduced in #145, plus a service file bug that prevents the timer from working.

**Description fixes:**
- Replaced incorrect "database is always installed fresh via `ddev drush si`" — the seed cache has no DDEV project, no database, no vendor files; it is a simple git checkout
- Fixed `ddev composer install` → `composer install` in the cache-hit description

**Migration step fixes** (the steps in #145 were incomplete — the timer never ran):
- Add install of `drupal-cache-updater.timer` (was missing entirely)
- Add `sed` to substitute `User=YOURUSER` placeholder in the service file (without this, the service fails to start)
- Add `systemctl enable --now drupal-cache-updater.timer` (without this, the hourly update is never scheduled)

**Service file fix:**
- `WorkingDirectory=%h` → `WorkingDirectory=/tmp` — `%h` causes "Permission denied" when the timer fires. The script uses only absolute paths so the working directory is irrelevant.

**Script fix:**
- Add reinstall reminder to `update-drupal-cache` so the deployed `/usr/local/bin/` copy must be updated manually after script changes

## Required admin action on each server

Run these steps to fix the installed service and get the timer working:

```bash
REPO=~/workspace/coder-ddev

# Reinstall the updated script and service file
sudo install -m 755 $REPO/drupal-core/scripts/update-drupal-cache \
  /usr/local/bin/update-drupal-cache
sudo install -m 644 $REPO/drupal-core/scripts/drupal-cache-updater.service \
  /etc/systemd/system/
sudo install -m 644 $REPO/drupal-core/scripts/drupal-cache-updater.timer \
  /etc/systemd/system/

# Fix User= placeholder if not already done
sudo grep -q YOURUSER /etc/systemd/system/drupal-cache-updater.service && \
  sudo sed -i "s/User=YOURUSER/User=$(whoami)/" /etc/systemd/system/drupal-cache-updater.service

# Reload and restart
sudo systemctl daemon-reload
sudo systemctl enable --now drupal-cache-updater.timer
sudo systemctl start drupal-cache-updater.service

# Verify
systemctl list-timers drupal-cache-updater.timer
journalctl -u drupal-cache-updater.service --no-pager | tail -10
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
