### PR TITLE
docs: fix template descriptions (#147); fix drupal-contrib allow-plugins for ddev poser, fixes #147

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,12 @@ TEMPLATE_EDIT_user-defined-web := --display-name "[DEPRECATED] DDEV Web Workspac
                                    --description "Deprecated: use the freeform template instead. Existing workspaces continue to work." \
                                    --deprecated "Deprecated: use the freeform template instead. Existing workspaces continue to work."
 TEMPLATE_EDIT_drupal-core      := --display-name "Drupal Core Development" \
-                                   --description "Drupal core dev environment: full DDEV stack, core clone, Umami demo site. Ready in about a minute."
+                                   --description "Drupal core dev environment: full DDEV stack, core clone, Umami demo site. Built on the amateescu/ddev-drupal-dev add-on."
 TEMPLATE_EDIT_drupal-contrib   := --display-name "Drupal Contrib Development" \
-                                   --description "Drupal contrib module/theme dev: clone any drupal.org project, optional issue branch checkout. Ready in 5-10 minutes."
-TEMPLATE_EDIT_freeform         := --display-name "DDEV Freeform (Traefik)" --default-ttl 24h
+                                   --description "Drupal contrib module/theme dev: clone any drupal.org project, optional issue branch. Uses ddev/ddev-drupal-contrib."
+TEMPLATE_EDIT_freeform         := --display-name "DDEV Freeform" \
+                                   --description "Multi-project DDEV workspace: each project gets its own URL via ddev-router Host-header routing." \
+                                   --default-ttl 24h
 
 # Shared recipe for pushing any template (call with template name as argument)
 define push_template

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ coder create --template user-defined-web my-workspace
 ### drupal-core (Drupal Core Development)
 Fully automated Drupal core development environment, including issue fork support.
 
-- **Setup**: Automatic (Drupal core cloned and installed, ~30s with seed cache)
+- **Setup**: Automatic (Drupal core cloned and installed)
 - **Use Case**: Drupal core development, contribution, patch testing
 - **Template Directory**: `drupal-core/`
 - **Issue Picker**: [start.coder.ddev.com/drupal-issue](https://start.coder.ddev.com/drupal-issue) — paste any drupal.org issue URL; the picker auto-detects core vs. contrib and routes to the right template
@@ -140,7 +140,7 @@ coder create --template drupal-core my-drupal-dev
 
 Automated environment for developing Drupal contrib modules and themes, with optional issue branch support.
 
-- **Setup**: Automatic (module/theme cloned, Drupal installed as dev dependency via `ddev-drupal-contrib`, ~5-10 min)
+- **Setup**: Automatic (module/theme cloned, Drupal installed as dev dependency via `ddev-drupal-contrib`)
 - **Use Case**: Contrib module/theme development, issue queue work on any drupal.org project
 - **Template Directory**: `drupal-contrib/`
 - **Issue Picker**: [start.coder.ddev.com/drupal-issue](https://start.coder.ddev.com/drupal-issue) — paste a drupal.org issue or project URL; auto-detects contrib

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -111,12 +111,13 @@ gh workflow run push-image.yml --ref <branch>
 ### Using the Makefile
 
 ```bash
-# Push all three templates (no image build — use when only HCL changed)
+# Push all four templates (no image build — use when only HCL changed)
 make push-all-templates
 
 # Push a single template
 make push-template-user-defined-web
 make push-template-drupal-core
+make push-template-drupal-contrib
 make push-template-freeform
 
 # Full deployment: build image, push image, push all templates
@@ -132,6 +133,7 @@ Set a default auto-stop so idle workspaces shut down and free resources. Run onc
 
 ```bash
 coder templates edit drupal-core      --default-ttl 2h --yes
+coder templates edit drupal-contrib   --default-ttl 2h --yes
 coder templates edit user-defined-web --default-ttl 2h --yes
 coder templates edit freeform         --default-ttl 2h --yes
 ```

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -840,16 +840,18 @@ Quick summary:
 git clone https://github.com/ddev/coder-ddev
 cd coder-ddev
 
-# Build the image, push it, and deploy all three templates
+# Build the image, push it, and deploy all four templates
 make deploy-user-defined-web
 make push-template-drupal-core
+make push-template-drupal-contrib
 make push-template-freeform
 ```
 
-This deploys three templates:
+This deploys four templates:
 - **user-defined-web** — general-purpose DDEV workspace; users configure their own project type
-- **freeform** — DDEV workspace using Traefik for more flexible routing
-- **drupal-core** — Drupal core development environment (see Step 10 for the recommended seed cache setup)
+- **drupal-core** — automated Drupal core development environment; clones Drupal core, installs the site, and sets up the [amateescu/ddev-drupal-dev](https://github.com/amateescu/ddev-drupal-dev) add-on (see Step 10 for the recommended seed cache setup)
+- **drupal-contrib** — automated environment for developing Drupal contrib modules and themes; uses the [ddev/ddev-drupal-contrib](https://github.com/ddev/ddev-drupal-contrib) add-on, which installs Drupal as a dev dependency and symlinks the module/theme into the web root
+- **freeform** — multi-project workspace: keeps ddev-router running so multiple DDEV projects can coexist in one workspace, each reachable at its own hostname via Host-header routing
 
 ---
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -489,7 +489,7 @@ coder start my-first-workspace
 # Via UI: Click "Start" button on workspace
 ```
 
-**Startup time:** about a minute (faster than initial create without cache)
+**Startup time:** faster than initial create (no reinstall needed)
 
 **After starting:**
 ```bash

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart: Drupal Core Development on coder.ddev.com
 
-Cloud-hosted DDEV workspaces for Drupal core development. Full environment — Drupal core clone, running site, drush — ready in about five minutes.
+Cloud-hosted DDEV workspaces for Drupal core development. Full environment — Drupal core clone, running site, drush — ready when the startup script completes.
 
 [![Open in Coder](https://coder.ddev.com/open-in-coder.svg)](https://coder.ddev.com/templates/coder/drupal-core/workspace?mode=manual)
 
@@ -16,7 +16,7 @@ Go to **[coder.ddev.com](https://coder.ddev.com)** and sign in with GitHub.
 
 Click the button above, or go to **Create Workspace** → select the **drupal-core** template → click **Create Workspace**.
 
-Wait about five minutes for the startup script to complete. Watch progress in the **Logs** tab.
+Wait for the startup script to complete. Watch progress in the **Logs** tab.
 
 ---
 
@@ -116,7 +116,7 @@ Then create a merge request on [drupal.org](https://www.drupal.org/project/drupa
 | Action | Effect |
 |--------|--------|
 | **Stop** workspace | Containers stop; your files persist on disk |
-| **Start** workspace | Ready in about a minute; no reinstall needed |
+| **Start** workspace | No reinstall needed; picks up where you left off |
 | **Delete** workspace | All data deleted permanently |
 
 ---

--- a/drupal-contrib/README.md
+++ b/drupal-contrib/README.md
@@ -36,12 +36,6 @@ coder create --template drupal-contrib issue-3568144 \
   --yes
 ```
 
-## Setup Time
-
-| Scenario | Time |
-|----------|------|
-| First workspace creation | 5–10 min (downloads Drupal + dependencies) |
-| Subsequent starts | ~1 min (restarts existing containers) |
 
 ## Workspace Structure
 

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -687,6 +687,11 @@ COMPOSE_EOF
         update_status "⏳ drush: Adding to composer.json..."
         jq '.["require-dev"]["drush/drush"] = "*"' composer.json > composer.json.tmp && mv composer.json.tmp composer.json
 
+        # Allow all Composer plugins in this dev environment. Composer 2.2+ blocks
+        # unknown plugins by default; modules can pull in arbitrary plugins (e.g.
+        # symfony/runtime) that aren't pre-listed in allow-plugins.
+        jq 'if .config == null then .config = {} else . end | .config["allow-plugins"] = true' composer.json > composer.json.tmp && mv composer.json.tmp composer.json
+
         # Run ddev poser: expands composer.json → composer.contrib.json (includes require-dev),
         # then runs composer install (installs Drupal + drush together), then removes composer.contrib.json
         log_setup "Running ddev poser (installs Drupal as dev dependency)..."

--- a/drupal-core/README.md
+++ b/drupal-core/README.md
@@ -17,16 +17,6 @@ Automated Coder workspace for Drupal core development using the [amateescu/ddev-
 - **Port Forwarding**: HTTP (80)
 - **Custom Launch Command**: `ddev launch` shows Coder-specific instructions
 
-## Initial Setup Time
-
-First workspace creation takes approximately **5-8 minutes**:
-
-- git clone (with cache seed reference hint): ~10s
-- DDEV start + add-on install: ~1 min
-- `ddev composer install`: ~2-3 min
-- Drupal site install (`ddev drush si`): ~2-3 min
-
-Subsequent starts are fast (< 1 minute) as everything is already present.
 
 ## Quick Start
 

--- a/freeform/README.md
+++ b/freeform/README.md
@@ -1,10 +1,11 @@
 # Freeform DDEV Template
 
-Coder workspace for a single DDEV project with full Traefik routing integration. Coder-aware routing rules are automatically configured so web, Mailpit, and optional Adminer are accessible via stable subdomains.
+Coder workspace for one or more DDEV projects in a single workspace. Each project gets its own stable subdomain URL via ddev-router (Traefik) Host-header routing — no port numbers in links, no conflicts between projects.
 
 ## Features
 
-- **Coder-Aware Traefik Routing**: DDEV web server and Mailpit get stable subdomain URLs (no port numbers in links)
+- **Multi-Project Support**: Run multiple DDEV projects in one workspace; each gets its own Coder app button and URL
+- **Coder-Aware Routing**: DDEV web server and Mailpit get stable subdomain URLs via ddev-router Host-header dispatch
 - **VS Code for Web**: Opens directly to your project directory
 - **Mailpit**: Email testing UI available as a Coder app
 - **Optional Adminer**: Database UI available when enabled via template variable


### PR DESCRIPTION
## Summary

- Add `drupal-contrib` to all places that previously listed only 3 templates (operations-guide.md, server-setup.md auto-stop TTL block and push commands)
- Link `drupal-core` and `drupal-contrib` to their scaffolds ([amateescu/ddev-drupal-dev](https://github.com/amateescu/ddev-drupal-dev) and [ddev/ddev-drupal-contrib](https://github.com/ddev/ddev-drupal-contrib)) in Makefile template descriptions and server-setup.md
- Fix freeform display name ("DDEV Freeform (Traefik)" → "DDEV Freeform") and description to correctly explain multi-project Host-header routing via ddev-router; fix freeform/README.md opener which incorrectly said "single DDEV project"
- Remove startup time estimates everywhere — they become stale and vary by server load
- Trim drupal-contrib and freeform Makefile descriptions to fit the 128-char database limit (caught on staging deploy)
- **Fix `ddev poser` failure for modules with arbitrary Composer plugins** (e.g. `skipto` + D12 pulling in `symfony/runtime`): set `config.allow-plugins = true` in `composer.json` via `jq` before running `ddev poser`, consistent with the existing drush injection. Composer 2.2+ blocks unknown plugins by default; contrib modules can't be expected to pre-list all transitive plugin deps.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)