### PR TITLE
fix: clean working tree after issue branch checkout, fixes #151

### DIFF
--- a/drupal-contrib/scripts/test-issue-branches.sh
+++ b/drupal-contrib/scripts/test-issue-branches.sh
@@ -95,6 +95,16 @@ for SPEC in "${TESTS[@]}"; do
       continue
     fi
     log "Checked out issue branch: $BRANCH"
+    DIRTY=$(git status --short 2>/dev/null)
+    if [ -n "$DIRTY" ]; then
+      log "ERROR: dirty git tree after issue branch checkout:"
+      echo "$DIRTY" | head -20
+      RESULTS["$DIR_KEY"]="FAIL (dirty git tree after checkout)"
+      DURATIONS["$DIR_KEY"]=$((SECONDS - START))
+      cd "$HOME"
+      continue
+    fi
+    log "✓ git tree clean after checkout"
   fi
 
   # --- Configure DDEV if needed ---

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -545,6 +545,12 @@ GIT_EXCLUDE_EOF
              git checkout -b "$ISSUE_BRANCH" "$REMOTE_NAME/$ISSUE_BRANCH" >> "$SETUP_LOG" 2>&1; then
             log_setup "✓ Checked out branch $ISSUE_BRANCH"
             update_status "✓ Branch checkout: Success"
+            # Ensure working tree exactly matches the checked-out branch.
+            # origin/main may be ahead of the issue branch base; git can leave
+            # files from those newer commits as modified/untracked after checkout.
+            git reset --hard HEAD >> "$SETUP_LOG" 2>&1 || true
+            git clean -fd >> "$SETUP_LOG" 2>&1 || true
+            log_setup "✓ Working tree reset to match branch"
           else
             log_setup "⚠ Warning: Could not checkout $ISSUE_BRANCH — remaining on current branch"
             update_status "⚠ Branch checkout: Warning"

--- a/drupal-core/scripts/test-issue-branches.sh
+++ b/drupal-core/scripts/test-issue-branches.sh
@@ -105,6 +105,16 @@ for PAIR in "${TESTS[@]}"; do
       cd "$HOME"
       continue
     fi
+    DIRTY=$(git status --short 2>/dev/null)
+    if [ -n "$DIRTY" ]; then
+      log "ERROR: dirty git tree after issue branch checkout:"
+      echo "$DIRTY" | head -20
+      RESULTS["$DIR_KEY"]="FAIL (dirty git tree after checkout)"
+      DURATIONS["$DIR_KEY"]=$((SECONDS - START))
+      cd "$HOME"
+      continue
+    fi
+    log "✓ git tree clean after checkout"
   elif [ "$TARGET_BRANCH" != "main" ]; then
     log "Checking out $TARGET_BRANCH..."
     if ! (git checkout -b "$TARGET_BRANCH" "origin/$TARGET_BRANCH" 2>&1 || \

--- a/drupal-core/scripts/update-drupal-cache
+++ b/drupal-core/scripts/update-drupal-cache
@@ -56,6 +56,10 @@ echo ""
 echo "Fetching Drupal core git objects..."
 git -C "$SEED_DIR" fetch --all --prune
 
+echo "Fast-forwarding local main branch..."
+git -C "$SEED_DIR" merge --ff-only origin/main || \
+  echo "Warning: could not fast-forward main (local changes?); objects still updated."
+
 echo ""
 echo "=== Seed cache updated successfully ==="
 echo "Completed: $(date)"

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -635,6 +635,13 @@ STATUS_HEADER
             if git -C "$DRUPAL_DIR" checkout -b "$ISSUE_BRANCH" "issue/$ISSUE_BRANCH" >> "$SETUP_LOG" 2>&1 || \
                git -C "$DRUPAL_DIR" checkout "$ISSUE_BRANCH" >> "$SETUP_LOG" 2>&1; then
               log_setup "  ✓ Checked out branch: $ISSUE_BRANCH"
+              # Ensure the working tree exactly matches the checked-out branch.
+              # When cloning with --reference, origin/main may be ahead of the
+              # issue branch base; git updates the index but can leave working tree
+              # files from those newer main commits behind as modified/untracked.
+              git -C "$DRUPAL_DIR" reset --hard HEAD >> "$SETUP_LOG" 2>&1 || true
+              git -C "$DRUPAL_DIR" clean -fd >> "$SETUP_LOG" 2>&1 || true
+              log_setup "  ✓ Working tree reset to match branch"
             else
               log_setup "✗ Failed to check out branch $ISSUE_BRANCH"
               SETUP_FAILED=true


### PR DESCRIPTION
## Summary

* #151 

- After checking out an issue fork branch, run `git reset --hard HEAD && git clean -fd` in both `drupal-core` and `drupal-contrib` templates so the working tree exactly matches the branch
- When cloning with `--reference`, `origin/main` may be ahead of the issue branch base; git correctly updates the index but can leave modified/untracked files from those newer main commits in the working tree
- Both `test-issue-branches.sh` scripts now check for a dirty tree immediately after issue branch checkout and fail if any modified or untracked files are present
- `update-drupal-cache` now fast-forwards the seed local `main` branch after fetching, keeping `git status` clean on the server

## Deployment note

After merging, reinstall `update-drupal-cache` on the production server:
```bash
sudo install -m 755 drupal-core/scripts/update-drupal-cache /usr/local/bin/update-drupal-cache
```

## Test plan

- [ ] Create a new `drupal-core` workspace with issue fork `3589595` / `3589595-fix-deprecation-version` and verify `git status` is clean after startup
- [ ] Run `bash drupal-core/scripts/test-issue-branches.sh 3589595:3589595-fix-deprecation-version:drupal12` locally — should pass the new dirty-tree check
- [ ] Run `bash drupal-contrib/scripts/test-issue-branches.sh` — should pass the new dirty-tree check
- [ ] Reinstall `update-drupal-cache` on the server and verify `git status` in `~/cache/drupal-core-seed` is clean after the next timer run

🤖 Generated with [Claude Code](https://claude.com/claude-code)