### PR TITLE
fix: create empty composer.json if it does not exist

### DIFF
--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -687,6 +687,10 @@ COMPOSE_EOF
       fi
 
       if [ "$DRUPAL_INSTALLED" = "false" ]; then
+        if [ ! -f composer.json ]; then
+           log_setup "Creating empty composer.json..."
+           echo '{}' > composer.json
+        fi
         # Add drush as require-dev so expand-composer-json includes it in composer.contrib.json.
         # Direct JSON edit (not `composer require`) per ddev-drupal-contrib README.
         log_setup "Adding drush to require-dev..."


### PR DESCRIPTION
Check for existence of composer.json before creating it.

## The Issue #159

## How This PR Solves The Issue

Creates the composer.json file if it does not exist.

## Manual Testing Instructions

Attempt to create an issue fork for https://www.drupal.org/project/config_update/issues/3174327

## Automated Testing Overview

N/A

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

