### PR TITLE
fix(drupal-contrib): harden ddev poser against codeload.github.com 400s

### DIFF
--- a/.github/workflows/drupal-contrib-integration-test.yml
+++ b/.github/workflows/drupal-contrib-integration-test.yml
@@ -435,7 +435,8 @@ jobs:
             --activate=false \
             --name ${{ env.WORKSPACE_NAME }} \
             --yes \
-            --variable workspace_image_registry=index.docker.io/ddev/coder-ddev
+            --variable workspace_image_registry=index.docker.io/ddev/coder-ddev \
+            --variable github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Create workspace
         run: |
@@ -586,7 +587,8 @@ jobs:
             --activate=false \
             --name gc-${{ github.run_number }}-${{ github.run_attempt }} \
             --yes \
-            --variable workspace_image_registry=index.docker.io/ddev/coder-ddev
+            --variable workspace_image_registry=index.docker.io/ddev/coder-ddev \
+            --variable github_token=${{ secrets.GITHUB_TOKEN }}
 
       - name: Create workspace
         run: |

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -44,6 +44,13 @@ variable "registry_password" {
   sensitive   = true
 }
 
+variable "github_token" {
+  description = "GitHub token passed to Composer as COMPOSER_AUTH to avoid codeload.github.com rate limits (optional)"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "image_version" {
   description = "The version of the Docker image to use"
   type        = string
@@ -702,6 +709,14 @@ COMPOSE_EOF
         # symfony/runtime) that aren't pre-listed in allow-plugins.
         jq 'if .config == null then .config = {} else . end | .config["allow-plugins"] = true' composer.json > composer.json.tmp && mv composer.json.tmp composer.json
 
+        # If a GitHub token is available, configure Composer OAuth so downloads use
+        # the authenticated GitHub API rather than anonymous codeload.github.com,
+        # which is prone to transient 400s and rate limits.
+        if [ -n "$${GITHUB_TOKEN:-}" ]; then
+          log_setup "Configuring Composer GitHub OAuth from GITHUB_TOKEN..."
+          ddev exec composer config --global github-oauth.github.com "$${GITHUB_TOKEN}" >> "$SETUP_LOG" 2>&1 || true
+        fi
+
         # Run ddev poser: expands composer.json → composer.contrib.json (includes require-dev),
         # then runs composer install (installs Drupal + drush together), then removes composer.contrib.json
         # Retry up to 3 times to handle transient codeload.github.com 400s.
@@ -1149,6 +1164,7 @@ resource "docker_container" "workspace" {
     "CODER_WORKSPACE_NAME=${data.coder_workspace.me.name}",
     "ELECTRON_DISABLE_SANDBOX=1",
     "ELECTRON_NO_SANDBOX=1",
+    "GITHUB_TOKEN=${var.github_token}",
   ]
 
   command = ["sh", "-c", coder_agent.main.init_script]

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -704,18 +704,29 @@ COMPOSE_EOF
 
         # Run ddev poser: expands composer.json → composer.contrib.json (includes require-dev),
         # then runs composer install (installs Drupal + drush together), then removes composer.contrib.json
-        log_setup "Running ddev poser (installs Drupal as dev dependency)..."
-        update_status "⏳ ddev poser: In progress..."
-        _t=$SECONDS
-        if ddev poser >> "$SETUP_LOG" 2>&1; then
-          log_setup "✓ ddev poser complete ($((SECONDS - _t))s)"
-          update_status "✓ ddev poser: Success"
-          # Hide the drush require-dev line from git status without touching the
-          # file — git checkout would remove drush from composer.json and break
-          # ddev restart (which rebuilds vendor/ from the restored file).
-          git update-index --skip-worktree composer.json >> "$SETUP_LOG" 2>&1 || true
-        else
-          log_setup "✗ ddev poser failed ($((SECONDS - _t))s)"
+        # Retry up to 3 times to handle transient codeload.github.com 400s.
+        _poser_ok=false
+        for _attempt in 1 2 3; do
+          log_setup "Running ddev poser (attempt $_attempt/3)..."
+          update_status "⏳ ddev poser: Attempt $_attempt/3..."
+          _t=$SECONDS
+          if ddev poser >> "$SETUP_LOG" 2>&1; then
+            log_setup "✓ ddev poser complete ($((SECONDS - _t))s)"
+            update_status "✓ ddev poser: Success"
+            # Hide the drush require-dev line from git status without touching the
+            # file — git checkout would remove drush from composer.json and break
+            # ddev restart (which rebuilds vendor/ from the restored file).
+            git update-index --skip-worktree composer.json >> "$SETUP_LOG" 2>&1 || true
+            _poser_ok=true
+            break
+          fi
+          log_setup "✗ ddev poser attempt $_attempt failed ($((SECONDS - _t))s)"
+          if [ "$_attempt" -lt 3 ]; then
+            log_setup "Retrying in 15s..."
+            sleep 15
+          fi
+        done
+        if [ "$_poser_ok" = "false" ]; then
           update_status "✗ ddev poser: Failed"
           SETUP_FAILED=true
         fi


### PR DESCRIPTION
## Summary

`codeload.github.com` intermittently returns HTTP/2 400 for Composer dist-zip downloads, causing `ddev poser` (which installs Drupal as a dev dependency) to fail with no recovery path. This manifested as all three plain matrix jobs failing in CI.

Two complementary fixes:

- **Retry loop**: `ddev poser` is retried up to 3 times with a 15s backoff. Composer is idempotent so retries skip already-downloaded packages and are fast when a partial download completed.
- **GitHub OAuth**: A `github_token` Terraform variable (sensitive, default empty) is passed into the workspace container as `GITHUB_TOKEN`. Before `ddev poser` runs, the startup script configures Composer GitHub OAuth (`composer config --global github-oauth.github.com`), so Composer uses the authenticated GitHub API rather than anonymous `codeload.github.com`. In CI the token comes from `secrets.GITHUB_TOKEN` passed via `--variable github_token=${{ secrets.GITHUB_TOKEN }}` at template push time.

The `GITHUB_TOKEN` approach is a CI-only fix for now — ordinary users creating workspaces manually would not have this token unless a separate mechanism (e.g. `coder external-auth`) is wired up, which is left as a follow-up.

The failing `Drupal Integration Tests` job (drupal-core template) is a pre-existing issue unrelated to this PR — it was also failing before these changes.

## Test plan

- [x] All three plain matrix jobs pass (token D11, pathauto D11, skipto D12)
- [x] Issue fork job passes
- [x] Startup log shows Composer GitHub OAuth configured when token is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)