### PR TITLE
feat: GitHub Pages PR preview for start.coder.ddev.com

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy Docs to GitHub Pages
+
+# Builds and deploys /docs to the root of the gh-pages branch on every push
+# to main that touches the docs directory. PR previews (in /pr-preview/) are
+# preserved across production deployments.
+#
+# GitHub Pages must be configured to serve from:
+#   Branch: gh-pages  /  (root)
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Jekyll site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          publish_branch: gh-pages
+          keep_files: true

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,45 @@
+name: Docs PR Preview
+
+# Deploys a preview of the /docs site to gh-pages at /pr-preview/pr-N/
+# and posts a comment with the URL on each PR.
+# On PR close, removes the preview automatically.
+#
+# After merging this workflow, change the GitHub Pages source to:
+#   Branch: gh-pages  /  (root)
+# Then trigger docs-deploy.yml once (workflow_dispatch) to populate gh-pages.
+#
+# Preview URLs: https://start.coder.ddev.com/pr-preview/pr-<N>/
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Jekyll site
+        uses: actions/jekyll-build-pages@v1
+        if: github.event.action != 'closed'
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          token: ${{ secrets.GITHUB_TOKEN }}
+          action: auto


### PR DESCRIPTION
## Summary

- Adds `docs-preview.yml`: builds the Jekyll `/docs` site on every PR, deploys a preview to the `gh-pages` branch at `/pr-preview/pr-<N>/`, and posts an automatic PR comment with the URL. Preview is removed when the PR closes.
- Adds `docs-deploy.yml`: rebuilds the production site on every push to `main` that touches `docs/`, preserving existing PR preview directories via `keep_files: true`.

## One-time setup required after merge

1. **Change GitHub Pages source**: Settings → Pages → Source: `gh-pages` branch, `/ (root)`
2. **Seed the branch**: Actions → "Deploy Docs to GitHub Pages" → Run workflow (populates `gh-pages` with current production content)
3. Verify `start.coder.ddev.com` still resolves correctly

## Known limitation

`keep_files: true` means deleted doc pages linger on `gh-pages` until manually removed — necessary to prevent production deploys from wiping active PR previews.

## Test plan

- [ ] Merge and complete one-time setup above
- [ ] Open a docs-only PR and confirm preview URL comment appears
- [ ] Visit the preview URL and verify the site renders
- [ ] Close the PR and confirm the preview comment is updated/removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)