### PR TITLE
fix(docs-workflows): add CNAME to deploy and rewrite URLs for PR previews

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -38,3 +38,4 @@ jobs:
           publish_dir: ./_site
           publish_branch: gh-pages
           keep_files: true
+          cname: start.coder.ddev.com

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -34,6 +34,10 @@ jobs:
           source: ./docs
           destination: ./_site
 
+      - name: Point preview at staging-coder.ddev.com
+        if: github.event.action != 'closed'
+        run: find ./_site -name "*.html" -exec sed -i 's|https://coder\.ddev\.com|https://staging-coder.ddev.com|g' {} +
+
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@v1
         with:


### PR DESCRIPTION
## Summary

- **CNAME on deploy**: adds `cname: start.coder.ddev.com` to the `peaceiris/actions-gh-pages` step so the `CNAME` file is always written to the `gh-pages` branch. Without this, the custom domain gets cleared whenever the deploy workflow runs.
- **Staging URLs in previews**: adds a `sed` pass after the Jekyll build in `docs-preview.yml` that rewrites every `https://coder.ddev.com` → `https://staging-coder.ddev.com` in the built HTML. This ensures preview links — workspace launch buttons, login URLs, the `CODER_BASE` JS constant in `drupal-issue.html`, and the `open-in-coder.svg` image — all point at staging rather than production.

## Test plan

- [ ] Merge and confirm `start.coder.ddev.com` stays live after the next `docs-deploy` run (CNAME file present on `gh-pages`)
- [ ] Open a docs PR and visit the preview URL — verify all `coder.ddev.com` links resolve to `staging-coder.ddev.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)