### PR TITLE
fix(docs-preview): cp _site to runner-owned dir before sed

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -36,12 +36,14 @@ jobs:
 
       - name: Point preview at staging-coder.ddev.com
         if: github.event.action != 'closed'
-        run: find ./_site -name "*.html" -exec sed -i 's|https://coder\.ddev\.com|https://staging-coder.ddev.com|g' {} +
+        run: |
+          cp -r ./_site ./_site_preview
+          find ./_site_preview -name "*.html" -exec sed -i 's|https://coder\.ddev\.com|https://staging-coder.ddev.com|g' {} +
 
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@v1
         with:
-          source-dir: ./_site
+          source-dir: ./_site_preview
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`jekyll-build-pages` runs in a Docker container as root, so the files it writes to `_site/` are root-owned. Both `chmod` and `sed -i` fail with "Operation not permitted" when the runner tries to modify them.

Fix: copy `_site/` to `_site_preview/` (the copy is owned by the runner) before running `sed`, then deploy from the copy.

## Test plan

- [ ] Open a docs PR and confirm the preview comment appears
- [ ] Verify all links in the preview point to `staging-coder.ddev.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)