### PR TITLE
Fix https scheme for Coder-fronted apps (X-Forwarded-Proto middleware)

### DIFF
--- a/docs/reference/coder-url-patterns.md
+++ b/docs/reference/coder-url-patterns.md
@@ -42,6 +42,8 @@ https://mailpit--myworkspace--rfay.coder.ddev.com/
 
 The Coder server terminates TLS and reverse-proxies to the `url` configured on the `coder_app` (e.g. `http://localhost:8025`). The wildcard TLS certificate must cover `*.coder.ddev.com`.
 
+**Scheme correction (X-Forwarded-Proto):** Because Coder terminates TLS and forwards to DDEV's Traefik over plain HTTP entrypoints (`tls: false`), Traefik would otherwise hand the backend `X-Forwarded-Proto: http`. Apps behind these routes (the TYPO3 backend, Vite/Astro dev servers, etc.) then generate `http://` URLs, and browsers break on the resulting `https://`→`http://` downgrade — e.g. TYPO3 throws `MissingReferrerException` on `/typo3/` because the browser drops the `Referer` header. To prevent this, `coder-routes` attaches a Traefik `headers` middleware (`{project}-coder-https`) to every generated router that forces `X-Forwarded-Proto: https` (plus `X-Forwarded-Ssl: on`, `X-Forwarded-Port: 443`), restoring the real external scheme the backend sees.
+
 **`share` options** — controls who can open the URL:
 
 | Value | Access |

--- a/image/scripts/.ddev/commands/host/coder-routes
+++ b/image/scripts/.ddev/commands/host/coder-routes
@@ -46,6 +46,19 @@ OUTPUT="$ROUTES_DIR/coder-routes-${DDEV_PROJECT}.yaml"
 # Seed the output file
 printf "http:\n  routers: {}\n" > /tmp/coder-routes-raw.yaml
 
+# HTTPS is always terminated at the Coder proxy (https://*.${DOMAIN}); Coder then
+# forwards to DDEV's Traefik over plain HTTP. Because these routers use HTTP
+# entrypoints (tls: false), Traefik would otherwise hand the backend
+# X-Forwarded-Proto: http, so apps (TYPO3 backend, Vite/Astro dev servers, etc.)
+# render http:// URLs and browsers break on the https->http downgrade (e.g. TYPO3
+# MissingReferrerException). This middleware restores the real external scheme.
+MW_NAME="${DDEV_PROJECT}-coder-https"
+yq e -i \
+  ".http.middlewares.\"${MW_NAME}\".headers.customRequestHeaders.\"X-Forwarded-Proto\" = \"https\" |
+   .http.middlewares.\"${MW_NAME}\".headers.customRequestHeaders.\"X-Forwarded-Ssl\" = \"on\" |
+   .http.middlewares.\"${MW_NAME}\".headers.customRequestHeaders.\"X-Forwarded-Port\" = \"443\"" \
+  /tmp/coder-routes-raw.yaml
+
 echo "Building Coder Traefik routes from ${DDEV_PROJECT}_merged.yaml:"
 
 # Iterate over every router in the merged config.
@@ -105,11 +118,12 @@ while IFS= read -r router; do
     # workspace name (the second component in the subdomain).
     CODER_HOST="${PROJECT_SLUG}--${WORKSPACE}--${OWNER}.${DOMAIN}"
     RULE='Host(`'"${CODER_HOST}"'`)'
-    RULE="$RULE" SVC="$service" \
+    RULE="$RULE" SVC="$service" MW="$MW_NAME" \
       yq e -i \
         ".http.routers.\"${ROUTER_NAME}\".entrypoints = [${ENTRY_LIST}] |
          .http.routers.\"${ROUTER_NAME}\".rule = env(RULE) |
          .http.routers.\"${ROUTER_NAME}\".service = env(SVC) |
+         .http.routers.\"${ROUTER_NAME}\".middlewares = [env(MW)] |
          .http.routers.\"${ROUTER_NAME}\".tls = false" \
       /tmp/coder-routes-raw.yaml
     echo "  + ${slug}: ${entrypoints[*]} → ${service}  (https://${CODER_HOST})"
@@ -118,11 +132,12 @@ while IFS= read -r router; do
     # use Host() rule so the Coder subdomain proxy URL routes correctly.
     CODER_HOST="${slug}--${WORKSPACE}--${OWNER}.${DOMAIN}"
     RULE='Host(`'"${CODER_HOST}"'`)'
-    RULE="$RULE" SVC="$service" \
+    RULE="$RULE" SVC="$service" MW="$MW_NAME" \
       yq e -i \
         ".http.routers.\"${ROUTER_NAME}\".entrypoints = [${ENTRY_LIST}] |
          .http.routers.\"${ROUTER_NAME}\".rule = env(RULE) |
          .http.routers.\"${ROUTER_NAME}\".service = env(SVC) |
+         .http.routers.\"${ROUTER_NAME}\".middlewares = [env(MW)] |
          .http.routers.\"${ROUTER_NAME}\".tls = false" \
       /tmp/coder-routes-raw.yaml
     echo "  + ${slug}: ${entrypoints[*]} → ${service}  (https://${CODER_HOST})"
@@ -132,11 +147,12 @@ while IFS= read -r router; do
     # https://{ext_port}--{agent}--{workspace}--{owner}.{domain}
     AGENT="${CODER_AGENT_NAME:-main}"
     RULE='PathPrefix(`/`)'
-    RULE="$RULE" SVC="$service" \
+    RULE="$RULE" SVC="$service" MW="$MW_NAME" \
       yq e -i \
         ".http.routers.\"${ROUTER_NAME}\".entrypoints = [${ENTRY_LIST}] |
          .http.routers.\"${ROUTER_NAME}\".rule = env(RULE) |
          .http.routers.\"${ROUTER_NAME}\".service = env(SVC) |
+         .http.routers.\"${ROUTER_NAME}\".middlewares = [env(MW)] |
          .http.routers.\"${ROUTER_NAME}\".tls = false |
          .http.routers.\"${ROUTER_NAME}\".priority = 1" \
       /tmp/coder-routes-raw.yaml


### PR DESCRIPTION
## Problem

Coder terminates TLS at `https://*.coder.ddev.com` and reverse-proxies to DDEV's Traefik over **plain-HTTP** entrypoints (the generated Coder routers use `tls: false`). As a result Traefik hands the backend `X-Forwarded-Proto: http`, and DDEV's nginx — which derives `HTTPS` solely from that header (`map $http_x_forwarded_proto $fcgi_https`) — reports `HTTPS=off` to PHP.

Apps then generate `http://` absolute URLs while the browser is on an `https://` page. The most visible casualty is the **TYPO3 backend**: `/typo3/` throws

```
#1588095935 TYPO3\CMS\Core\Http\Security\MissingReferrerException
```

because its `referrer-refresh` redirect is stamped `http://`, and the browser drops the `Referer` header on the `https://`→`http://` downgrade. Frontend rendering, canonical tags, sitemaps, and generated emails are affected by the same scheme misdetection.

## Fix

`coder-routes` now defines a Traefik `headers` middleware (`{project}-coder-https`) and attaches it to **every** generated router. Since HTTPS always terminates at the Coder proxy, it forces the real external scheme:

```yaml
middlewares:
  {project}-coder-https:
    headers:
      customRequestHeaders:
        X-Forwarded-Proto: https
        X-Forwarded-Ssl: on
        X-Forwarded-Port: "443"
```

This is generic across all Coder-fronted services (web backend, mailpit, xhgui, and dynamic port-forward dev servers such as Vite/Astro).

## Verification

Probed through the exact `http-8080` entrypoint the Coder proxy uses, with **no** client-supplied forwarded header:

| | before | after |
|---|---|---|
| `HTTPS` seen by PHP | `off` | `on` |
| `X-Forwarded-Proto` | absent | `https` |

TYPO3 now detects HTTPS, renders `https://` backend URLs, and `/typo3/` loads without `MissingReferrerException`.

## Changes

- `image/scripts/.ddev/commands/host/coder-routes` — define + attach the middleware
- `docs/reference/coder-url-patterns.md` — document the scheme-correction behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)