### PR TITLE
fix(drupal-core): install Drush via Guzzle alias while Drush lags core's Guzzle 8 bump

### DIFF
--- a/drupal-core/scripts/test-issue-branches.sh
+++ b/drupal-core/scripts/test-issue-branches.sh
@@ -148,7 +148,18 @@ for PAIR in "${TESTS[@]}"; do
   ddev composer install 2>&1 || COMPOSER_EXIT=$?
 
   if [ "$COMPOSER_EXIT" = "0" ]; then
-    ddev composer require drush/drush 2>&1 | tail -5
+    # Mirrors the Drush install in template.tf: fall back to an inline Guzzle
+    # alias while Drush still requires guzzlehttp/guzzle ^7.0 and core main
+    # requires ^8.0 (drush-ops/drush#6602).
+    DRUSH_EXIT=0
+    ddev composer require drush/drush > /tmp/drush-require.log 2>&1 || DRUSH_EXIT=$?
+    tail -5 /tmp/drush-require.log
+    if [ "$DRUSH_EXIT" != "0" ]; then
+      GUZZLE_VER=$(jq -r '.packages[] | select(.name == "guzzlehttp/guzzle") | .version' composer.lock 2>/dev/null || true)
+      case "$GUZZLE_VER" in
+        8.*) ddev composer require "guzzlehttp/guzzle:$GUZZLE_VER as 7.99.0" drush/drush -W 2>&1 | tail -5 ;;
+      esac
+    fi
   fi
 
   # --- Record result ---

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -922,12 +922,39 @@ WELCOME_STATIC
       if [ "$SETUP_FAILED" != "true" ]; then
         log_setup "Adding Drush to composer.local.json..."
         update_status "⏳ Drush install: In progress..."
+        _drush_ok=false
         if ddev composer require drush/drush >> "$SETUP_LOG" 2>&1; then
+          _drush_ok=true
+        else
+          # Drush's Guzzle constraint lags core's. Core main moved to
+          # guzzlehttp/guzzle ^8.0 on 2026-07-24 (drupal.org issue #3612544)
+          # while every Drush version still requires ^7.0, so a plain
+          # `composer require drush/drush` is unsatisfiable against Drupal 12
+          # HEAD. Guzzle 8 works with Drush at runtime, so retry with an inline
+          # alias presenting the locked Guzzle version as a 7.x one. Composer
+          # only accepts an exact version as an alias source, hence reading it
+          # from composer.lock. Remove this fallback once Drush ships Guzzle 8
+          # support (drush-ops/drush#6602).
+          _guzzle_ver=$(jq -r '.packages[] | select(.name == "guzzlehttp/guzzle") | .version' composer.lock 2>/dev/null || true)
+          case "$_guzzle_ver" in
+            8.*)
+              log_setup "Drush/Guzzle constraint conflict — retrying with guzzle $_guzzle_ver aliased as 7.99.0..."
+              if ddev composer require "guzzlehttp/guzzle:$_guzzle_ver as 7.99.0" drush/drush -W >> "$SETUP_LOG" 2>&1; then
+                _drush_ok=true
+              fi
+              ;;
+          esac
+        fi
+        if [ "$_drush_ok" = "true" ]; then
           log_setup "✓ Drush installed"
           update_status "✓ Drush install: Success"
         else
-          log_setup "⚠ Warning: Failed to install Drush (non-critical)"
-          update_status "⚠ Drush install: Warning"
+          # Every later step (site install, cache rebuild, uli) runs through
+          # Drush, so treat this as fatal instead of emitting a cascade of
+          # "drush is not available" errors.
+          log_setup "✗ Failed to install Drush — cannot install Drupal without it"
+          update_status "✗ Drush install: Failed"
+          SETUP_FAILED=true
         fi
       fi
     fi


### PR DESCRIPTION
## Summary

Drupal core `main` moved to `guzzlehttp/guzzle: "^8.0"` on 2026-07-24 ([drupal.org #3612544](https://www.drupal.org/project/drupal/issues/3612544), core commit `6e1efec8a`) while every Drush version still requires `^7.0`. That makes `ddev composer require drush/drush` unsatisfiable against Drupal 12 HEAD, so every `drupal12` workspace has been failing its Drupal install for the last day — the setup log shows `Failed to install Drush (non-critical)` followed by a cascade of `drush is not available` errors from `drush si` / `drush cr`.

Nothing in this repo, DDEV, or the add-on is involved: the same conflict reproduces from a 6-line `composer.json` with no site and no DDEV.

- **Fall back to an inline Guzzle alias** when the plain require fails. Guzzle 8 works with Drush at runtime, so `composer require "guzzlehttp/guzzle:<locked> as 7.99.0" drush/drush -W` installs unmodified upstream Drush from Packagist. The version is read from `composer.lock` because Composer rejects a range as an alias source (`the alias source must be an exact version`), and the fallback is gated on Guzzle `8.*` so it can't misfire on 11.x/10.x workspaces.
- **The plain require still runs first**, so the fallback stops being reached the day Drush tags Guzzle 8 support ([drush-ops/drush#6602](https://github.com/drush-ops/drush/pull/6602), a one-line constraint change) and the block can simply be deleted. No coordinated cleanup needed.
- **Treat a Drush install failure as fatal.** Every later step (site install, cache rebuild, `uli`) runs through Drush, so the old "non-critical" warning only buried the real cause under downstream errors.
- Mirror the same fallback in `drupal-core/scripts/test-issue-branches.sh`, and capture the require's exit code there — the previous `cmd | tail -5` form meant the script tested `tail`'s status, so a failure wouldn't have been detected without `pipefail`.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes for `drupal-core`
- [x] `terraform test` passes for `drupal-core` (6 passed)
- [x] `bash -n drupal-core/scripts/test-issue-branches.sh` clean
- [x] Reproduced the failure in a live `drupal-core` workspace on core HEAD: plain `ddev composer require drush/drush` exits 1; `-W` also fails with `Conclusion: don't install drupal/core 12.x-dev`
- [x] Verified the fallback in that workspace: installs upstream `drush/drush 14.x-dev` against `guzzlehttp/guzzle 8.0.0`, then `drush si -y demo_umami` → `[OK] Installation complete`, `drush cr` OK, `drush status` → `Drupal bootstrap: Successful`, `Install profile: demo_umami`
- [x] Verified the same one-liner fixes a plain local `drupal/recommended-project` D12 site (outside Coder)
- [ ] Fresh `drupal12` workspace build from the pushed template (not yet run — the fallback was exercised by hand in an existing workspace, in the same order the template runs it)

## Notes

- `drupal-contrib` with **Drupal Version = 12** is very likely broken the same way — it adds `drush/drush` to `require-dev` and resolves via `ddev poser`. Not addressed here: it defaults to `11`, and the fix there can't read a lock file (the solve fails before one exists), so it needs a different, separately tested approach.
- Drush's own CI on #6602 is currently red on the `test-*-functional` jobs. I confirmed which jobs failed but didn't read the CircleCI logs, so I can't say whether that's real Guzzle 8 breakage in paths beyond the three commands exercised above. The workaround produces the same runtime state the merged PR would, either way.
- Drupal 11.x and 10.x workspaces are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
