### PR TITLE
fix: don't configure the external-auth URL as a Composer GitHub token

### DIFF
--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -717,12 +717,33 @@ COMPOSE_EOF
         if [ -z "$${_COMPOSER_GITHUB_TOKEN}" ]; then
           _CODER_BIN=$(find /tmp -name "coder" -path "*/coder.*/*" -type f -executable 2>/dev/null | head -1)
           if [ -n "$${_CODER_BIN}" ]; then
-            _COMPOSER_GITHUB_TOKEN=$("$${_CODER_BIN}" external-auth access-token github 2>/dev/null || true)
+            # `coder external-auth access-token` prints the token to stdout and exits 0,
+            # but when the user has no linked GitHub account it prints the *authentication
+            # URL* to stdout and exits 1. The exit code must be honored: handing that URL
+            # to Composer as an OAuth token makes every github.com dist download fail with
+            # "Could not authenticate against github.com" and suppresses the anonymous
+            # fallback, which is strictly worse than configuring no token at all.
+            if _token=$("$${_CODER_BIN}" external-auth access-token github 2>/dev/null); then
+              _COMPOSER_GITHUB_TOKEN="$_token"
+            else
+              log_setup "No linked GitHub account — using anonymous Composer downloads"
+            fi
           fi
+        fi
+        # An expired or revoked token fails the same opaque way, so verify before use.
+        if [ -n "$${_COMPOSER_GITHUB_TOKEN}" ] && \
+           ! curl -sSf --max-time 10 -o /dev/null -H "Authorization: Bearer $${_COMPOSER_GITHUB_TOKEN}" https://api.github.com/user 2>/dev/null; then
+          log_setup "⚠ GitHub token rejected by api.github.com — using anonymous Composer downloads"
+          _COMPOSER_GITHUB_TOKEN=""
         fi
         if [ -n "$${_COMPOSER_GITHUB_TOKEN}" ]; then
           log_setup "Configuring Composer GitHub OAuth..."
           ddev exec composer config --global github-oauth.github.com "$${_COMPOSER_GITHUB_TOKEN}" >> "$SETUP_LOG" 2>&1 || true
+        else
+          # Clear any token a previous run configured. Composer's global config lives in
+          # a persistent DDEV volume, so a bad value keeps breaking every later start
+          # even once this code stops writing one.
+          ddev exec composer config --global --unset github-oauth.github.com >> "$SETUP_LOG" 2>&1 || true
         fi
 
         # Run ddev poser: expands composer.json → composer.contrib.json (includes require-dev),

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -887,12 +887,33 @@ WELCOME_STATIC
         if [ -z "$${_COMPOSER_GITHUB_TOKEN}" ]; then
           _CODER_BIN=$(find /tmp -name "coder" -path "*/coder.*/*" -type f -executable 2>/dev/null | head -1)
           if [ -n "$${_CODER_BIN}" ]; then
-            _COMPOSER_GITHUB_TOKEN=$("$${_CODER_BIN}" external-auth access-token github 2>/dev/null || true)
+            # `coder external-auth access-token` prints the token to stdout and exits 0,
+            # but when the user has no linked GitHub account it prints the *authentication
+            # URL* to stdout and exits 1. The exit code must be honored: handing that URL
+            # to Composer as an OAuth token makes every github.com dist download fail with
+            # "Could not authenticate against github.com" and suppresses the anonymous
+            # fallback, which is strictly worse than configuring no token at all.
+            if _token=$("$${_CODER_BIN}" external-auth access-token github 2>/dev/null); then
+              _COMPOSER_GITHUB_TOKEN="$_token"
+            else
+              log_setup "No linked GitHub account — using anonymous Composer downloads"
+            fi
           fi
+        fi
+        # An expired or revoked token fails the same opaque way, so verify before use.
+        if [ -n "$${_COMPOSER_GITHUB_TOKEN}" ] && \
+           ! curl -sSf --max-time 10 -o /dev/null -H "Authorization: Bearer $${_COMPOSER_GITHUB_TOKEN}" https://api.github.com/user 2>/dev/null; then
+          log_setup "⚠ GitHub token rejected by api.github.com — using anonymous Composer downloads"
+          _COMPOSER_GITHUB_TOKEN=""
         fi
         if [ -n "$${_COMPOSER_GITHUB_TOKEN}" ]; then
           log_setup "Configuring Composer GitHub OAuth..."
           ddev exec composer config --global github-oauth.github.com "$${_COMPOSER_GITHUB_TOKEN}" >> "$SETUP_LOG" 2>&1 || true
+        else
+          # Clear any token a previous run configured. Composer's global config lives in
+          # a persistent DDEV volume, so a bad value keeps breaking every later start
+          # even once this code stops writing one.
+          ddev exec composer config --global --unset github-oauth.github.com >> "$SETUP_LOG" 2>&1 || true
         fi
 
         # Retry up to 3 times to handle transient codeload.github.com 400s.
@@ -1006,9 +1027,13 @@ WELCOME_STATIC
     fi
     fi # end SETUP_FAILED guard
 
-    # Step 6.5: Cache rebuild — ensures a clean state after any setup path
-    log_setup "Running cache rebuild..."
-    ddev drush cr >> "$SETUP_LOG" 2>&1 || true
+    # Step 6.5: Cache rebuild — ensures a clean state after any successful setup path.
+    # Skipped when setup failed: there is no installed site to rebuild, and running it
+    # anyway just appends a confusing "drush is not available" error to the log.
+    if [ "$SETUP_FAILED" != "true" ]; then
+      log_setup "Running cache rebuild..."
+      ddev drush cr >> "$SETUP_LOG" 2>&1 || true
+    fi
 
     # Step 6.6: Set up phpunit.xml for running core tests
     if [ ! -f "phpunit.xml" ] && [ -f "phpunit-ddev.xml" ]; then


### PR DESCRIPTION
## Summary

A `drupal12` workspace on staging failed all three `composer install` attempts with `Could not authenticate against github.com`, and never reached the Drupal install. The cause is the Composer GitHub OAuth token setup added in #166.

`coder external-auth access-token github` prints the token to stdout and exits 0 — but when the user has no linked GitHub account it prints the **authentication URL** to stdout and exits 1. The capture discarded that exit code with `|| true`, so the workspace configured this as its OAuth token:

```
[github-oauth.github.com] https://staging-coder.ddev.com/external-auth/github
```

Composer then failed every dist download and, because it disables source fallback once authentication fails, never retried anonymously:

```
Failed to download mglaman/composer-drupal-lenient from dist: Could not authenticate against github.com
    Source fallback is disabled. Not trying alternative sources.
In AuthHelper.php line 152:
  Could not authenticate against github.com
```

The retry loop can't help — nothing about this is transient. **A bad token is strictly worse than no token**: with none, Composer downloads anonymously and succeeds. Verified in the failing workspace — unsetting the value alone makes `ddev composer install` exit 0.

- **Honor the exit code**, so only a real token is used.
- **Validate the token** against `api.github.com/user` before configuring it, so an expired or revoked `GITHUB_TOKEN` fails loudly here rather than opaquely mid-install. This matters for the CI path in particular: `drupal-integration-test.yml` passes GitHub Actions' ephemeral `secrets.GITHUB_TOKEN` as a template variable, so any workspace created from that template version *after* the workflow ends gets a long-expired token.
- **Unset any token a previous run configured** when we don't have a valid one. Composer's global config lives in a persistent DDEV volume, so a bad value keeps breaking every later start even once this code stops writing one — without this, already-affected workspaces stay broken.
- **Skip the cache rebuild when `SETUP_FAILED` is set.** It sat outside the guard and appended a misleading `drush is not available` / `Failed to run drush cr` after the real failure, burying the cause.

Applied to `drupal-contrib` too, which had a byte-identical copy of the token block. (Its separate Drupal-12 Guzzle problem is untouched — see #179.)

## Why this surfaced now

Not a Coder change. Both deployments run identical Coder (`v2.34.4+19d9274`) with different `deployment_id`s, so external-auth links are per-deployment. The only recent commit touching `coder external-auth access-token` (coder/coder#26883) is not in any release, and preserves the exit-code behavior anyway.

The bug has been latent since #166. Three paths supply a token, and only the third is broken:

| Path | `github_token` var | external-auth link | Result |
| --- | --- | --- | --- |
| Human workspace on production | empty | linked | real token — worked for weeks |
| CI integration-test workspace | set via `--variable github_token=` | not consulted | real token — CI green |
| Human workspace on staging | empty (`staging-push.yml` doesn't pass it) | absent | URL used as token — **fails** |

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes for `drupal-core` and `drupal-contrib`
- [x] `terraform test` passes for both (6 + 6)
- [x] `bash -n` on both rendered `startup_script` heredocs (Terraform escapes resolved) — `terraform validate` does not check the embedded shell
- [x] Reproduced in a live staging workspace: `[github-oauth.github.com]` held the external-auth URL; clearing it made `ddev composer install` exit 0
- [x] Exercised all three new paths in that workspace: `access-token` exit 1 → URL not used; garbage token → rejected by the `api.github.com/user` check; `--unset` → safe no-op when nothing is configured
- [x] Ran the remaining setup steps verbatim afterward: Drush installed via the Guzzle fallback, `drush si -y demo_umami` → `[OK] Installation complete`, `drush cr` OK, bootstrap successful, `http 200`
- [ ] Fresh workspace built from the pushed template — not yet run

## Release/Deployment Notes

The fix makes an unlinked account a clean anonymous-download path rather than a hard failure. If authenticated downloads are wanted for ordinary users, that's a separate change: add `data "coder_external_auth" "github" { id = "github"; optional = true }` so Coder surfaces a "Login with GitHub" button at workspace creation. No template currently declares one, which is why nothing ever prompted for the link.

Workspaces already poisoned by the old code self-heal on next start via the `--unset` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
