### PR TITLE
feat(cleanup): notify Discord when a workspace deletion is threatened

### DIFF
--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -459,10 +459,12 @@ On the server, all of this is supplied via `/etc/workspace-lifecycle-cleanup.env
 The script needs to list *every* user's workspaces (`coder list --all`) and delete workspaces it doesn't own. On this deployment (no Premium license, so no custom RBAC roles), `owner` is the only built-in role that can do both — there's no narrower "workspace admin" role available. That makes this token effectively full site-admin, so it's provisioned as a dedicated non-human account rather than a personal token:
 
 ```bash
-# 0. Raise the server's max token lifetime first — Coder caps --lifetime at
-#    CODER_MAX_TOKEN_LIFETIME (default 168h/1 week), which is too short for an
-#    unattended daily timer. Add to /etc/coder.d/coder.env, then `sudo systemctl restart coder`:
-#      CODER_MAX_TOKEN_LIFETIME=8760h
+# 0. Raise the server's max *admin* token lifetime first — Coder caps --lifetime
+#    for owner-role accounts at CODER_MAX_ADMIN_TOKEN_LIFETIME (default 168h/1
+#    week; the much larger CODER_MAX_TOKEN_LIFETIME default doesn't apply to
+#    owner accounts), which is too short for an unattended daily timer. Add to
+#    /etc/coder.d/coder.env, then `sudo systemctl restart coder`:
+#      CODER_MAX_ADMIN_TOKEN_LIFETIME=8760h
 
 # 1. Create a machine identity — no GitHub OAuth login required
 coder users create --username workspace-janitor \

--- a/docs/admin/operations-guide.md
+++ b/docs/admin/operations-guide.md
@@ -426,6 +426,8 @@ Policy per workspace, based on `last_used_at`:
 - **7 more days idle after the notice** — the workspace is deleted with `coder delete --yes`.
 - If the owner uses the workspace again before deletion, the pending notice is cleared automatically.
 
+Both the notice and the eventual deletion are visible in Discord if [coder-discord-relay](./server-setup.md#step-11-set-up-discord-notifications) is set up: the notice email triggers a direct **Workspace Deletion Threatened** post to the relay (`DISCORD_RELAY_URL`, best-effort — a missing or unreachable relay never blocks the email), and the later `coder delete` call is picked up natively as Coder's own **Workspace Deleted** event, same as any other deletion.
+
 State (which workspaces have been notified and when) is tracked in a local JSON file on the server (`/var/lib/workspace-lifecycle-cleanup/state.json` by default) — it never needs to leave the box, so there's no commit-back-to-git step to manage.
 
 ```bash

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -1234,8 +1234,6 @@ Get a fresh registration token for each batch from **GitHub → Settings → Act
 
 #### 2. Create the CI bot user on staging
 
-`--lifetime 8760h` requires `CODER_MAX_TOKEN_LIFETIME=8760h` in `/etc/coder.d/coder.env` on staging-coder.ddev.com (Coder's default cap is `168h`) — see [Step 14](#step-14-set-up-workspace-lifecycle-cleanup) for the same setting on production. Restart Coder after adding it before running the commands below.
-
 ```bash
 coder users create --email ci@staging-coder.ddev.com --username ci-bot --login-type none
 coder users edit-roles ci-bot --roles template-admin --yes
@@ -1284,12 +1282,12 @@ Stopped workspaces don't free their Docker volumes — each Sysbox workspace kee
 
 This is set up on **coder.ddev.com (production) only**. staging-coder.ddev.com doesn't need it: its workspaces are almost entirely owned by `ci-bot` (already excluded via the default `EXCLUDE_OWNERS`), it isn't sending real notices to real people, and `./scripts/workspace-lifecycle-cleanup.sh` (no `--force`) already gives a safe dry-run preview against production itself when you need to sanity-check the policy — no separate staging deployment adds coverage. If that changes (e.g. staging starts accumulating real user workspaces), repeat these steps there with its own `workspace-janitor` account/token and a verified Mailgun domain for staging.
 
-### Raise the server's max token lifetime
+### Raise the server's max admin token lifetime
 
-Coder caps `coder tokens create --lifetime` at `CODER_MAX_TOKEN_LIFETIME` (default `168h`, i.e. 1 week). A weekly-rotation requirement isn't workable for an unattended daily timer, so raise the cap before minting the janitor's token. Add to `/etc/coder.d/coder.env`:
+`workspace-janitor` is granted the `owner` role below, so its token lifetime is capped by `CODER_MAX_ADMIN_TOKEN_LIFETIME` (default `168h`, i.e. 1 week) — not `CODER_MAX_TOKEN_LIFETIME` (default `876600h`/100 years), which only bounds non-admin tokens. A weekly-rotation requirement isn't workable for an unattended daily timer, so raise the admin cap before minting the janitor's token. Add to `/etc/coder.d/coder.env`:
 
 ```bash
-CODER_MAX_TOKEN_LIFETIME=8760h
+CODER_MAX_ADMIN_TOKEN_LIFETIME=8760h
 ```
 
 Then restart Coder:

--- a/docs/admin/server-setup.md
+++ b/docs/admin/server-setup.md
@@ -1084,6 +1084,7 @@ This should post a message to your Discord channel.
 - Workspace created/deleted messages show `<owner>/<workspace>`
 - Coder fans a single event out to one webhook call per recipient (e.g. one per user admin); the relay dedupes identical `notification_name`+labels pairs within a 30-second window so this only posts once to Discord
 - If you regenerate the Discord webhook URL, update `/etc/coder-discord-relay.env` and restart the relay
+- `scripts/workspace-lifecycle-cleanup.sh` also posts directly to this relay (`http://localhost:9876/` by default) whenever it emails an owner about an idle workspace, so threatened deletions show up in Discord the same way actual `coder delete` calls already do via **Workspace Deleted** — see [Automated Idle Workspace Cleanup](./operations-guide.md#automated-idle-workspace-cleanup)
 
 ---
 

--- a/scripts/coder-discord-relay
+++ b/scripts/coder-discord-relay
@@ -84,6 +84,16 @@ class CoderWebhookHandler(BaseHTTPRequestHandler):
                 initiator = labels.get("initiator", "?")
                 reason = labels.get("reason", "")
                 message = f"**Workspace deleted:** `{owner}/{workspace}` by {initiator}" + (f" ({reason})" if reason and reason != "initiated by user" else "")
+            elif event == "Workspace Deletion Threatened":
+                # Not a real Coder notification — scripts/workspace-lifecycle-cleanup.sh
+                # posts this synthetic event directly in the same envelope shape
+                # when it emails an owner that their idle workspace will be
+                # deleted soon.
+                owner = labels.get("workspace_owner_username", "?")
+                workspace = labels.get("workspace", "?")
+                idle_days = labels.get("idle_days", "?")
+                delete_date = labels.get("delete_date", "?")
+                message = f"**Workspace deletion threatened:** `{owner}/{workspace}` idle {idle_days}d — will be deleted {delete_date} unless used"
             elif "User account" in event:
                 # labels vary; fall back to title which contains the username
                 message = f"**{data.get('title', event)}**"

--- a/scripts/workspace-lifecycle-cleanup.sh
+++ b/scripts/workspace-lifecycle-cleanup.sh
@@ -65,6 +65,10 @@
 #   MAILGUN_FROM        From header (default: "DDEV Coder <support@ddev.com>")
 #   ANNOUNCE_URL        Blog post explaining the auth change
 #                       (default: https://ddev.com/blog/coder-ddev-com-announcement/)
+#   DISCORD_RELAY_URL   coder-discord-relay endpoint to notify when a notice
+#                       email goes out (default: http://localhost:9876/; set
+#                       empty to disable). Best-effort — a failed or missing
+#                       relay never blocks the notice email itself.
 #
 # Usage:
 #   ./scripts/workspace-lifecycle-cleanup.sh                            # dry run
@@ -81,6 +85,7 @@ STATE_FILE="${STATE_FILE:-scripts/state/workspace-lifecycle-state.json}"
 MAILGUN_BASE_URL="${MAILGUN_BASE_URL:-https://api.mailgun.net/v3}"
 MAILGUN_FROM="${MAILGUN_FROM:-DDEV Coder <support@ddev.com>}"
 ANNOUNCE_URL="${ANNOUNCE_URL:-https://ddev.com/blog/coder-ddev-com-announcement/}"
+DISCORD_RELAY_URL="${DISCORD_RELAY_URL-http://localhost:9876/}"
 FORCE=false
 PURGE_IDLE_DAYS=""
 
@@ -304,6 +309,29 @@ EOF
   fi
 }
 
+# Best-effort: tell coder-discord-relay a notice went out, so admins see
+# threatened deletions in Discord the same way they already see actual
+# `coder delete` calls (via Coder's native "Workspace Deleted" event). A
+# missing or unreachable relay must never fail the run — it's informational.
+post_discord_notice() {
+  local owner_name="$1" workspace_name="$2" idle_days="$3" delete_date_human="$4"
+
+  [[ "$FORCE" == true && -n "$DISCORD_RELAY_URL" ]] || return 0
+
+  local payload
+  payload=$(jq -n \
+    --arg owner "$owner_name" --arg ws "$workspace_name" \
+    --arg days "$idle_days" --arg date "$delete_date_human" \
+    '{payload: {notification_name: "Workspace Deletion Threatened",
+                labels: {workspace_owner_username: $owner, workspace: $ws,
+                         idle_days: $days, delete_date: $date}}}')
+
+  if ! curl -sf -X POST -H "Content-Type: application/json" \
+    -d "$payload" "$DISCORD_RELAY_URL" >/dev/null; then
+    echo "  WARN: Discord relay notice for ${owner_name}/${workspace_name} failed (non-fatal)" >&2
+  fi
+}
+
 notified=0 revived=0 deleted=0 pending=0 kept=0 pruned=0 failed=0
 notified_details=() revived_details=() deleted_details=() pending_details=() pruned_details=() failed_details=()
 
@@ -396,6 +424,7 @@ while IFS=$'\t' read -r id name owner last_used_at; do
     if send_notice_email "$owner_email" "${owner_display:-$owner}" "$name" "$last_used_human" "$delete_date_human"; then
       notified=$((notified + 1))
       notified_details+=("$owner/$name <$owner_email> — idle ${age_days}d, last used $last_used_human, deletes $delete_date_human unless used")
+      post_discord_notice "$owner" "$name" "$age_days" "$delete_date_human"
       state_json=$(echo "$state_json" | jq --arg id "$id" --arg at "$(epoch_to_iso "$now")" --arg name "$name" --arg owner "$owner" \
         '.[$id] = {notified_at: $at, name: $name, owner: $owner}')
       persist_state


### PR DESCRIPTION
## Summary

- `coder delete` calls the workspace-lifecycle janitor makes already surface in Discord via Coder's native **Workspace Deleted** event (relayed by `coder-discord-relay`), but the janitor's own 7-day idle-notice email is a raw Mailgun call outside Coder's notification system entirely — so a threatened deletion was invisible until the day it actually happened.
- `workspace-lifecycle-cleanup.sh` now POSTs a synthetic **Workspace Deletion Threatened** event to the same relay whenever it successfully emails an owner, giving admins the same passive Discord visibility for threatened deletions as for actual ones.
- New `DISCORD_RELAY_URL` env var (default `http://localhost:9876/`, matching the relay's existing listen address; set empty to disable). Best-effort — a missing or unreachable relay never blocks the notice email or fails the run.
- `coder-discord-relay` gains a handler for this event, formatting it as `**Workspace deletion threatened:** owner/workspace idle Nd — will be deleted DATE unless used`.
- Also folds in a docs fix from an earlier PR that landed without it: the token-lifetime cap workspace-janitor actually hits is `CODER_MAX_ADMIN_TOKEN_LIFETIME` (default 168h, applies only to the `owner` role per `coderd/apikey.go`), not `CODER_MAX_TOKEN_LIFETIME` (default 876600h, never the binding constraint here).

## Test plan

- [x] `bash -n` and `shellcheck` clean on `workspace-lifecycle-cleanup.sh`
- [x] `python3 -m py_compile` clean on `coder-discord-relay`
- [x] Ran the relay locally and posted a synthetic `Workspace Deletion Threatened` payload — confirmed correct message formatting and dedup/routing logic
- [x] Deployed both updated scripts to coder.ddev.com; restarted `coder-discord-relay`; fired the same synthetic test event directly at the running relay and confirmed it posted correctly to the real Discord channel
- [x] Ran the updated `workspace-lifecycle-cleanup` dry run against real production workspace data — no regressions
- [ ] Full real end-to-end (`--force` run hitting an actually-idle workspace, invoking `post_discord_notice` for real) will be exercised by next week's scheduled timer run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
