### PR TITLE
revert: remove Drush/Guzzle alias workarounds now that upstream is fixed

### DIFF
--- a/drupal-contrib/scripts/test-issue-branches.sh
+++ b/drupal-contrib/scripts/test-issue-branches.sh
@@ -135,25 +135,7 @@ for SPEC in "${TESTS[@]}"; do
     ddev exec composer require --dev drush/drush --no-update --no-interaction 2>&1 | tail -5
 
     log "Running ddev poser..."
-    POSER_RC=0
-    ddev poser > /tmp/poser-attempt.log 2>&1 || POSER_RC=$?
-    tail -10 /tmp/poser-attempt.log
-    # Mirrors the Guzzle alias fallback in template.tf: Drush still requires
-    # guzzlehttp/guzzle ^7.0 while core main requires ^8.0, which makes a plain
-    # poser run unsolvable on Drupal 12 HEAD. Removal tracked in #179
-    # (upstream: drush-ops/drush#6602).
-    if [ "$POSER_RC" != "0" ] && grep -q "drush/drush.*requires guzzlehttp/guzzle" /tmp/poser-attempt.log; then
-      GUZZLE_VER=$(curl -fsSL --max-time 30 https://repo.packagist.org/p2/guzzlehttp/guzzle.json 2>/dev/null |
-        jq -r '[.packages["guzzlehttp/guzzle"][].version | select(test("^8[.][0-9]+[.][0-9]+$"))] | sort_by(split(".") | map(tonumber)) | last // empty' 2>/dev/null || true)
-      if [ -n "$GUZZLE_VER" ]; then
-        log "Drush/Guzzle conflict — retrying poser with guzzle $GUZZLE_VER aliased as 7.99.0..."
-        jq --arg v "$GUZZLE_VER as 7.99.0" '.["require-dev"]["guzzlehttp/guzzle"] = $v' composer.json > composer.json.tmp && mv composer.json.tmp composer.json
-        POSER_RC=0
-        ddev poser > /tmp/poser-attempt.log 2>&1 || POSER_RC=$?
-        tail -10 /tmp/poser-attempt.log
-      fi
-    fi
-    if [ "$POSER_RC" != "0" ]; then
+    if ! ddev poser 2>&1 | tail -10; then
       log "ERROR: ddev poser failed"
       RESULTS["$DIR_KEY"]="FAIL (ddev poser)"
       DURATIONS["$DIR_KEY"]=$((SECONDS - START))

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -750,18 +750,11 @@ COMPOSE_EOF
         # then runs composer install (installs Drupal + drush together), then removes composer.contrib.json
         # Retry up to 3 times to handle transient codeload.github.com 400s.
         _poser_ok=false
-        _guzzle_aliased=false
         for _attempt in 1 2 3; do
           log_setup "Running ddev poser (attempt $_attempt/3)..."
           update_status "⏳ ddev poser: Attempt $_attempt/3..."
           _t=$SECONDS
-          # Capture this attempt separately so the conflict check below cannot
-          # match output from an earlier attempt or an earlier workspace start
-          # ($SETUP_LOG is append-only across restarts).
-          _poser_rc=0
-          ddev poser > /tmp/poser-attempt.log 2>&1 || _poser_rc=$?
-          cat /tmp/poser-attempt.log >> "$SETUP_LOG"
-          if [ "$_poser_rc" = "0" ]; then
+          if ddev poser >> "$SETUP_LOG" 2>&1; then
             log_setup "✓ ddev poser complete ($((SECONDS - _t))s)"
             update_status "✓ ddev poser: Success"
             # Hide the drush require-dev line from git status without touching the
@@ -772,37 +765,6 @@ COMPOSE_EOF
             break
           fi
           log_setup "✗ ddev poser attempt $_attempt failed ($((SECONDS - _t))s)"
-
-          # Drush's Guzzle constraint lags core's: core main moved to
-          # guzzlehttp/guzzle ^8.0 on 2026-07-24 (drupal.org #3612544) while
-          # every Drush version still requires ^7.0, so Composer cannot solve
-          # drush/drush against Drupal 12 HEAD. Guzzle 8 works with Drush at
-          # runtime, so retry with an inline alias presenting a Guzzle 8 release
-          # as a 7.x one — the same workaround #178 added to drupal-core, which
-          # deliberately left this template alone because the version cannot be
-          # read from a lock file here: ddev poser resolves core and Drush in one
-          # solve and deletes composer.contrib.lock afterwards. Composer only
-          # accepts an exact version as an alias source, so ask packagist for the
-          # newest stable 8.x instead. Applied only on this specific failure, so
-          # Drupal 11 builds (core requires Guzzle ^7) keep resolving normally,
-          # and it self-clears once Drush is fixed. Unlike drupal-core, where the
-          # alias lands in gitignored composer.local.json, here it lands in the
-          # module's tracked composer.json — the skip-worktree call above keeps
-          # it out of git status, same as the drush require-dev line. Removal is
-          # tracked in #179 (upstream: drush-ops/drush#6602).
-          if [ "$_guzzle_aliased" = "false" ] && \
-             grep -q "drush/drush.*requires guzzlehttp/guzzle" /tmp/poser-attempt.log; then
-            _guzzle_ver=$(curl -fsSL --max-time 30 https://repo.packagist.org/p2/guzzlehttp/guzzle.json 2>/dev/null |
-              jq -r '[.packages["guzzlehttp/guzzle"][].version | select(test("^8[.][0-9]+[.][0-9]+$"))] | sort_by(split(".") | map(tonumber)) | last // empty' 2>/dev/null || true)
-            if [ -n "$_guzzle_ver" ]; then
-              log_setup "Drush/Guzzle constraint conflict — retrying with guzzle $_guzzle_ver aliased as 7.99.0..."
-              jq --arg v "$_guzzle_ver as 7.99.0" '.["require-dev"]["guzzlehttp/guzzle"] = $v' composer.json > composer.json.tmp && mv composer.json.tmp composer.json
-              _guzzle_aliased=true
-              continue
-            fi
-            log_setup "⚠ Could not determine a stable Guzzle 8 version from packagist"
-          fi
-
           if [ "$_attempt" -lt 3 ]; then
             log_setup "Retrying in 15s..."
             sleep 15

--- a/drupal-core/scripts/test-issue-branches.sh
+++ b/drupal-core/scripts/test-issue-branches.sh
@@ -148,18 +148,7 @@ for PAIR in "${TESTS[@]}"; do
   ddev composer install 2>&1 || COMPOSER_EXIT=$?
 
   if [ "$COMPOSER_EXIT" = "0" ]; then
-    # Mirrors the Drush install in template.tf: fall back to an inline Guzzle
-    # alias while Drush still requires guzzlehttp/guzzle ^7.0 and core main
-    # requires ^8.0 (drush-ops/drush#6602).
-    DRUSH_EXIT=0
-    ddev composer require drush/drush > /tmp/drush-require.log 2>&1 || DRUSH_EXIT=$?
-    tail -5 /tmp/drush-require.log
-    if [ "$DRUSH_EXIT" != "0" ]; then
-      GUZZLE_VER=$(jq -r '.packages[] | select(.name == "guzzlehttp/guzzle") | .version' composer.lock 2>/dev/null || true)
-      case "$GUZZLE_VER" in
-        8.*) ddev composer require "guzzlehttp/guzzle:$GUZZLE_VER as 7.99.0" drush/drush -W 2>&1 | tail -5 ;;
-      esac
-    fi
+    ddev composer require drush/drush 2>&1 | tail -5
   fi
 
   # --- Record result ---

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -943,39 +943,12 @@ WELCOME_STATIC
       if [ "$SETUP_FAILED" != "true" ]; then
         log_setup "Adding Drush to composer.local.json..."
         update_status "⏳ Drush install: In progress..."
-        _drush_ok=false
         if ddev composer require drush/drush >> "$SETUP_LOG" 2>&1; then
-          _drush_ok=true
-        else
-          # Drush's Guzzle constraint lags core's. Core main moved to
-          # guzzlehttp/guzzle ^8.0 on 2026-07-24 (drupal.org issue #3612544)
-          # while every Drush version still requires ^7.0, so a plain
-          # `composer require drush/drush` is unsatisfiable against Drupal 12
-          # HEAD. Guzzle 8 works with Drush at runtime, so retry with an inline
-          # alias presenting the locked Guzzle version as a 7.x one. Composer
-          # only accepts an exact version as an alias source, hence reading it
-          # from composer.lock. Remove this fallback once Drush ships Guzzle 8
-          # support (drush-ops/drush#6602).
-          _guzzle_ver=$(jq -r '.packages[] | select(.name == "guzzlehttp/guzzle") | .version' composer.lock 2>/dev/null || true)
-          case "$_guzzle_ver" in
-            8.*)
-              log_setup "Drush/Guzzle constraint conflict — retrying with guzzle $_guzzle_ver aliased as 7.99.0..."
-              if ddev composer require "guzzlehttp/guzzle:$_guzzle_ver as 7.99.0" drush/drush -W >> "$SETUP_LOG" 2>&1; then
-                _drush_ok=true
-              fi
-              ;;
-          esac
-        fi
-        if [ "$_drush_ok" = "true" ]; then
           log_setup "✓ Drush installed"
           update_status "✓ Drush install: Success"
         else
-          # Every later step (site install, cache rebuild, uli) runs through
-          # Drush, so treat this as fatal instead of emitting a cascade of
-          # "drush is not available" errors.
-          log_setup "✗ Failed to install Drush — cannot install Drupal without it"
-          update_status "✗ Drush install: Failed"
-          SETUP_FAILED=true
+          log_setup "⚠ Warning: Failed to install Drush (non-critical)"
+          update_status "⚠ Drush install: Warning"
         fi
       fi
     fi


### PR DESCRIPTION
## Summary
- Reverts the temporary Drush/Guzzle workarounds added in #178 and #181.
- Drupal core's composer.json already sets minimum-stability: dev, so a plain `composer require drush/drush` now resolves cleanly to `drush/drush 14.x-dev` (which requires `guzzlehttp/guzzle ^7.8.2 || ^8.0`, per [drush-ops/drush#6602](https://github.com/drush-ops/drush/pull/6602)) — no alias or explicit version pin needed.
- Verified live against a fresh Drupal core HEAD checkout in a disposable container: `composer require drush/drush` resolved `drush/drush (14.x-dev a83d7e0)` alongside `guzzlehttp/guzzle 8.0.0` with no conflict.
- Mirrors the equivalent revert done upstream in [ddev/ddev#8621](https://github.com/ddev/ddev/pull/8621).

## Test plan
- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` for `drupal-core` and `drupal-contrib`
- [x] `terraform test` for `drupal-core` and `drupal-contrib` — 6/6 passing each
- [x] Live-verified `composer require drush/drush` resolution against Drupal core HEAD in a scratch container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
