### PR TITLE
fix(scripts): recognize linuxbrew volumes in the orphaned-volume cleanup sweep

### DIFF
--- a/scripts/cleanup-deleted-workspaces.sh
+++ b/scripts/cleanup-deleted-workspaces.sh
@@ -88,8 +88,10 @@ echo
 # --- Docker volumes ---
 orphan_volumes=()
 while IFS= read -r vol; do
-  # Volume names look like: coder-<owner>-<workspace>-dind-cache
-  if [[ "$vol" =~ ^coder-(.+)-dind-cache$ ]]; then
+  # Volume names look like: coder-<owner>-<workspace>-dind-cache or
+  # coder-<owner>-<workspace>-linuxbrew. Add any new persistent per-workspace
+  # volume suffix here too, or orphans of that type will go undetected.
+  if [[ "$vol" =~ ^coder-(.+)-(dind-cache|linuxbrew)$ ]]; then
     owner_workspace="${BASH_REMATCH[1]}"
     if [[ -z "${active_dirs[$owner_workspace]+_}" ]]; then
       orphan_volumes+=("$vol")

--- a/scripts/workspace-lifecycle-cleanup.sh
+++ b/scripts/workspace-lifecycle-cleanup.sh
@@ -2,12 +2,14 @@
 # Notify and delete idle workspaces on coder.ddev.com.
 #
 # Why this exists:
-#   Stopping a workspace does not free its Docker volume — each Sysbox
-#   workspace keeps a multi-GB dind-cache volume until the workspace is
-#   deleted (the destroy provisioner in each template removes it). With no
-#   lifecycle policy, stopped workspaces accumulate forever and slowly fill
-#   /data on the host. This janitor enforces: notify at N days idle, delete
-#   7 days after the notice if the workspace is still untouched.
+#   Stopping a workspace does not free its Docker volumes — each Sysbox
+#   workspace keeps a multi-GB dind-cache volume and a linuxbrew volume until
+#   the workspace is deleted (Terraform destroys them, along with everything
+#   else in the workspace's resource graph, when the workspace itself is
+#   deleted). With no lifecycle policy, stopped workspaces accumulate forever
+#   and slowly fill /data on the host. This janitor enforces: notify at N
+#   days idle, delete 7 days after the notice if the workspace is still
+#   untouched.
 #
 # Policy (state machine per workspace, keyed by workspace id):
 #   - Not yet notified, age(last_used_at) >= NOTIFY_DAYS


### PR DESCRIPTION
## Summary
- The orphan-volume sweep in `cleanup-deleted-workspaces.sh` only matched the `-dind-cache` volume suffix, so an orphaned `-linuxbrew` volume (from an interrupted destroy, state desync, etc.) would never be flagged for cleanup.
- Extends the matching regex to `^coder-(.+)-(dind-cache|linuxbrew)$`, with an inline comment reminding future maintainers to extend the alternation for any new persistent per-workspace volume type.
- Tightens a comment in `workspace-lifecycle-cleanup.sh`: volumes are removed because Terraform destroys them along with the rest of the workspace's resource graph, not by "the destroy provisioner" (a separate, narrower mechanism that only handles the host-bind-mounted `/home/coder` directory) — and mentions the linuxbrew volume.

## Test plan
- [x] `bash -n` syntax check on both scripts
- [x] No Terraform files touched, so no `terraform fmt`/`validate`/`test` needed
- [ ] Live verification against a real orphaned `-linuxbrew` volume in production (requires a real Coder deployment with an orphaned volume present)

Note: both scripts are installed manually on `coder.ddev.com` — merging this PR alone doesn't update the live copy; the server-side script needs a manual refresh too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)