### PR TITLE
fix(coder-routes): fix router collisions with web_extra_exposed_ports

### DIFF
--- a/image/scripts/.ddev/commands/host/coder-routes
+++ b/image/scripts/.ddev/commands/host/coder-routes
@@ -81,18 +81,27 @@ while IFS= read -r router; do
   [ ${#entrypoints[@]} -eq 0 ] && continue
 
   # Derive Coder slug from service name: strip {ddev_project}- prefix and -{port} suffix.
+  # The port here is the web *container* port (80/8025/...), not the host-published port.
   # Examples (DDEV_PROJECT=myproject, WORKSPACE=myworkspace):
-  #   myproject-web-8080    → svc=web  port=8080  → slug=PROJECT_SLUG (primary web)
+  #   myproject-web-80      → svc=web  port=80    → slug=PROJECT_SLUG (primary web)
   #   myproject-web-8025    → svc=web  port=8025  → slug=mailpit-PROJECT_SLUG
   #   myproject-xhgui-80    → svc=xhgui          → slug=xhgui-PROJECT_SLUG
   #   myproject-adminer-9100 → svc=adminer         → slug=adminer-PROJECT_SLUG
+  #   myproject-web-4321    → svc=web  port=4321  → falls through to the dynamic
+  #                           add-on branch below (PathPrefix rule), e.g. a
+  #                           web_extra_exposed_ports container_port. Only container
+  #                           port 80 is treated as the primary web app — any other
+  #                           "web" service/port must NOT also claim slug=PROJECT_SLUG,
+  #                           or its router silently clobbers the primary site's router
+  #                           (same map key) since both would compute the same
+  #                           ROUTER_NAME.
   svc_and_port="${service#${DDEV_PROJECT}-}"
   port="${svc_and_port##*-}"
   svc_name="${svc_and_port%-*}"
 
   if [ "$svc_name" = "web" ] && [ "$port" = "8025" ]; then
     slug="mailpit-${PROJECT_SLUG}"
-  elif [ "$svc_name" = "web" ]; then
+  elif [ "$svc_name" = "web" ] && [ "$port" = "80" ]; then
     slug="$PROJECT_SLUG"
   elif [ "$svc_name" = "xhgui" ]; then
     slug="xhgui-${PROJECT_SLUG}"
@@ -145,6 +154,13 @@ while IFS= read -r router; do
     # Dynamic add-on services (no dedicated coder_app): PathPrefix("/") catches any
     # traffic arriving on this entrypoint, enabling Coder port-forwarding URLs:
     # https://{ext_port}--{agent}--{workspace}--{owner}.{domain}
+    #
+    # priority must beat ddev-router's own built-in catch-all fallback router
+    # (ddev-router-fallback-http/-https, baked into every workspace's
+    # default_config.yaml), which also uses PathPrefix(`/`) at priority 1 on
+    # every entrypoint. A tie at priority 1 is resolved in the fallback's
+    # favor, so this router would never actually receive traffic — it silently
+    # loses to DDEV's generic "no route found" page. Any priority > 1 wins.
     AGENT="${CODER_AGENT_NAME:-main}"
     RULE='PathPrefix(`/`)'
     RULE="$RULE" SVC="$service" MW="$MW_NAME" \
@@ -154,7 +170,7 @@ while IFS= read -r router; do
          .http.routers.\"${ROUTER_NAME}\".service = env(SVC) |
          .http.routers.\"${ROUTER_NAME}\".middlewares = [env(MW)] |
          .http.routers.\"${ROUTER_NAME}\".tls = false |
-         .http.routers.\"${ROUTER_NAME}\".priority = 1" \
+         .http.routers.\"${ROUTER_NAME}\".priority = 10" \
       /tmp/coder-routes-raw.yaml
     echo "  + ${slug}: ${entrypoints[*]} → ${service}  (https://${ext_port}--${AGENT}--${WORKSPACE}--${OWNER}.${DOMAIN})"
   fi


### PR DESCRIPTION
## Summary
- `coder-routes` derived the Coder slug for any Traefik router whose service was named `{project}-web-{port}` (except port 8025) as the primary site, with no check on which port. A project using `web_extra_exposed_ports` (e.g. an Astro/Vite dev server on a second port) gets a second `web`-named service (`{project}-web-4321`), which computed the same slug/router name as the real primary site (`{project}-web-80`). Whichever was processed last silently clobbered the other's router in the merged YAML map, breaking the main site's `coder_app` URL and misrouting the extra port under the wrong `Host()` rule instead of the port-forwarding `PathPrefix` rule.
- The dynamic add-on branch (used for ports with no dedicated `coder_app`, reached via Coder's dashboard port-forwarding URLs) set `PathPrefix(`/`)` at `priority: 1`. Every workspace's built-in catch-all fallback router (`ddev-router-fallback-http`/`-https`, baked into `default_config.yaml`) uses the identical rule at the identical priority, and the tie resolves in the fallback's favor — so these routers never actually received traffic, silently swallowed by DDEV's generic "no route found" page.

## Fix
1. Restrict the primary-site slug match to container port `80` specifically, so any other `web`-named port falls through to the dynamic add-on branch instead of colliding with the primary site.
2. Bump the dynamic add-on router's priority from `1` to `10` so it beats the built-in fallback router.

Reproduced and verified against a live workspace (ddev.com project with `web_extra_exposed_ports`/`web_extra_daemons` for an Astro dev server on port 4321/4322): before the fix, both the main site's coder URL and the port-forward URL for 4322 returned 404; after the fix, both return 200, confirmed via direct `curl` against each Traefik entrypoint with the exact `Host` headers Coder sends.

## Test plan
- [ ] `terraform fmt -recursive` / `terraform validate` (no `.tf` changes in this PR, script-only)
- [x] Manually verified against a live freeform-template workspace running a project with `web_extra_exposed_ports` configured — main site, mailpit, and the extra-port dashboard-forward URL all route correctly after regenerating routes with the fixed script
- [ ] CI integration test (`.github/workflows/integration-test.yml`) exercises `coder-routes` against a real workspace

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_018ZFiSd6KTRmRNFzAhpL1eE