### PR TITLE
Add Go VS Code extension by default, DRY the extensions list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ The `freeform` template is unique: it keeps ddev-router running so multiple DDEV
 ## Tool Preferences
 
 - Use `jq` (not `python3 -m json.tool`) for JSON pretty-printing and querying
+- For `git commit -m` and `gh pr create --body`, write the message to a file first (e.g. under the scratchpad directory) and pass it via `git commit -F <file>` / `gh pr create --body-file <file>`, rather than inlining a heredoc on the command line. Multi-paragraph messages containing backticks, apostrophes, or other shell-special characters reliably break inline heredoc quoting.
 
 ## Before Pushing / Pre-push Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,18 +59,22 @@ Run these before every push to avoid CI failures:
 # Terraform formatting (CI runs terraform fmt -check -recursive)
 terraform fmt -recursive
 
-# Terraform validation for each template you touched
-terraform -chdir=drupal-core init -backend=false && terraform -chdir=drupal-core validate
-terraform -chdir=drupal-contrib init -backend=false && terraform -chdir=drupal-contrib validate
-terraform -chdir=freeform init -backend=false && terraform -chdir=freeform validate
-
-# Terraform tests (plan-level, no real infrastructure)
-terraform -chdir=drupal-core test
-terraform -chdir=drupal-contrib test
-terraform -chdir=freeform test
+# Vendor shared assets, then validate + test every template
+make validate
+make test-templates
 ```
 
 `terraform fmt -recursive` must be run from the repo root. It is non-destructive (rewrites in place) and the CI check fails with exit code 3 if any file is not formatted.
+
+**Always use `make validate` / `make test-templates`, not raw `terraform validate`/`terraform test` run directly in a template directory.** Both targets depend on `make sync-shared`, which vendors `modules/claude-remote-control` and `shared/vscode-extensions.tf` into each template directory first (see "Shared Terraform Assets" below). Running `terraform validate`/`test` directly against a template dir will happily validate against a stale vendored copy and miss the fact that it's out of sync with the canonical source.
+
+## Shared Terraform Assets
+
+Some Terraform config (currently `modules/claude-remote-control` and `shared/vscode-extensions.tf`) is shared across all three templates but must exist as a **physical copy inside each template directory** — `coder templates push` and CI's `terraform validate`/`test` only ever operate on a single template directory, so a relative `../modules` or `../shared` reference would not survive the push and would not be visible to CI.
+
+- **Edit only the canonical source**: `modules/claude-remote-control/` or `shared/vscode-extensions.tf` at the repo root. Never hand-edit the vendored copies (`<template>/modules/claude-remote-control/`, `<template>/vscode-extensions.tf`) — they get overwritten the next time anyone runs the sync.
+- **Always resync through `make`**, never by hand-copying: `make sync-shared` (or `make sync-claude-module` / `make sync-vscode-extensions` individually). `make validate`, `make test-templates`, and every `make push-template-*` / `make push-all-templates` target already depend on `sync-shared`, so day-to-day you rarely need to invoke it directly.
+- **Commit the vendored copies.** They are tracked files, not build artifacts — CI validates each template directory standalone with no `make` step, so the vendored copies must already be correct and committed for CI to pass.
 
 ## Working with Coder Workspaces via SSH
 

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,18 @@ sync-claude-module: ## Vendor modules/claude-remote-control into each template d
 	done
 	@echo "Synced modules/claude-remote-control into: $(TEMPLATES)"
 
+.PHONY: sync-vscode-extensions
+sync-vscode-extensions: ## Vendor shared/vscode-extensions.tf into each template dir (same reason as sync-claude-module: push only bundles the given --directory)
+	@for t in $(TEMPLATES); do \
+		cp shared/vscode-extensions.tf $$t/vscode-extensions.tf; \
+	done
+	@echo "Synced shared/vscode-extensions.tf into: $(TEMPLATES)"
+
+.PHONY: sync-shared
+sync-shared: sync-claude-module sync-vscode-extensions ## Vendor all shared Terraform assets (modules + vscode-extensions.tf) into each template dir
+
 .PHONY: validate
-validate: sync-claude-module ## Validate all Terraform templates (requires terraform in PATH)
+validate: sync-shared ## Validate all Terraform templates (requires terraform in PATH)
 	@for t in $(TEMPLATES); do \
 		echo "--- Validating $$t ---"; \
 		(cd $$t && terraform init -backend=false -input=false -no-color && terraform validate -no-color) || exit 1; \
@@ -125,7 +135,7 @@ fmt-check: ## Check Terraform formatting across all templates
 	terraform fmt -check -recursive
 
 .PHONY: test-templates
-test-templates: sync-claude-module ## Run Terraform mock unit tests for all templates (requires terraform in PATH)
+test-templates: sync-shared ## Run Terraform mock unit tests for all templates (requires terraform in PATH)
 	@for t in $(TEMPLATES); do \
 		echo "--- Testing $$t ---"; \
 		(cd $$t && terraform test) || exit 1; \
@@ -170,15 +180,15 @@ info: ## Show image and template information
 # --- Template push targets ---
 
 .PHONY: push-template-drupal-core
-push-template-drupal-core: sync-claude-module ## Push drupal-core template to Coder
+push-template-drupal-core: sync-shared ## Push drupal-core template to Coder
 	$(call push_template,drupal-core)
 
 .PHONY: push-template-drupal-contrib
-push-template-drupal-contrib: sync-claude-module ## Push drupal-contrib template to Coder
+push-template-drupal-contrib: sync-shared ## Push drupal-contrib template to Coder
 	$(call push_template,drupal-contrib)
 
 .PHONY: push-template-freeform
-push-template-freeform: sync-claude-module ## Push freeform template to Coder
+push-template-freeform: sync-shared ## Push freeform template to Coder
 	$(call push_template,freeform)
 
 .PHONY: push-all-templates

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -190,12 +190,12 @@ data "coder_parameter" "vscode_extensions" {
   description  = "Select extensions to enable in VS Code for Web"
   type         = "list(string)"
   form_type    = "multi-select"
-  default      = jsonencode([for e in var.vscode_extensions : e.id if e.default])
+  default      = jsonencode([for e in local.vscode_extensions : e.id if e.default])
   mutable      = true
   order        = 100
 
   dynamic "option" {
-    for_each = var.vscode_extensions
+    for_each = local.vscode_extensions
     content {
       name  = option.value.name
       value = option.value.id

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -224,31 +224,6 @@ locals {
   workspace_image_registry_base = replace(local.registry_without_version, ":latest", "")
 }
 
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
-    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
-    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
-    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
-    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
-    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
-    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
-    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
-    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
-    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
-    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
-    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
-    { id = "redhat.vscode-yaml", name = "YAML", default = false },
-    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
-    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
-  ]
-}
-
 variable "workspace_image_registry" {
   description = "Docker registry URL for the workspace base image (without tag, version is added automatically)"
   type        = string

--- a/drupal-contrib/vscode-extensions.tf
+++ b/drupal-contrib/vscode-extensions.tf
@@ -1,0 +1,25 @@
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "golang.go", name = "Go", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
+}

--- a/drupal-contrib/vscode-extensions.tf
+++ b/drupal-contrib/vscode-extensions.tf
@@ -1,11 +1,10 @@
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
+locals {
+  # Deliberately a `locals`, not a `variable`: Coder pins the submitted value of any
+  # root-level `variable` block server-side the first time a template is pushed, and
+  # reuses that pinned value on later pushes instead of re-reading this file's list
+  # unless `--variable vscode_extensions=...` is passed again. `locals` are recomputed
+  # fresh on every plan, so there is nothing for Coder to pin.
+  vscode_extensions = [
     { id = "xdebug.php-debug", name = "PHP Debug", default = true },
     { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
     { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -224,31 +224,6 @@ locals {
   workspace_image_registry_base = replace(local.registry_without_version, ":latest", "")
 }
 
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
-    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
-    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
-    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
-    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
-    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
-    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
-    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
-    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
-    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
-    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
-    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
-    { id = "redhat.vscode-yaml", name = "YAML", default = false },
-    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
-    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
-  ]
-}
-
 variable "workspace_image_registry" {
   description = "Docker registry URL for the workspace base image (without tag, version is added automatically)"
   type        = string

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -172,12 +172,12 @@ data "coder_parameter" "vscode_extensions" {
   description  = "Select extensions to enable in VS Code for Web"
   type         = "list(string)"
   form_type    = "multi-select"
-  default      = jsonencode([for e in var.vscode_extensions : e.id if e.default])
+  default      = jsonencode([for e in local.vscode_extensions : e.id if e.default])
   mutable      = true
   order        = 100
 
   dynamic "option" {
-    for_each = var.vscode_extensions
+    for_each = local.vscode_extensions
     content {
       name  = option.value.name
       value = option.value.id

--- a/drupal-core/vscode-extensions.tf
+++ b/drupal-core/vscode-extensions.tf
@@ -1,0 +1,25 @@
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "golang.go", name = "Go", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
+}

--- a/drupal-core/vscode-extensions.tf
+++ b/drupal-core/vscode-extensions.tf
@@ -1,11 +1,10 @@
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
+locals {
+  # Deliberately a `locals`, not a `variable`: Coder pins the submitted value of any
+  # root-level `variable` block server-side the first time a template is pushed, and
+  # reuses that pinned value on later pushes instead of re-reading this file's list
+  # unless `--variable vscode_extensions=...` is passed again. `locals` are recomputed
+  # fresh on every plan, so there is nothing for Coder to pin.
+  vscode_extensions = [
     { id = "xdebug.php-debug", name = "PHP Debug", default = true },
     { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
     { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -113,31 +113,6 @@ locals {
   )
 }
 
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
-    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
-    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
-    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
-    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
-    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
-    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
-    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
-    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
-    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
-    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
-    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
-    { id = "redhat.vscode-yaml", name = "YAML", default = false },
-    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
-    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
-  ]
-}
-
 variable "workspace_image_registry" {
   description = "Docker registry URL for the workspace base image (without tag)"
   type        = string

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -82,12 +82,12 @@ data "coder_parameter" "vscode_extensions" {
   description  = "Select extensions to enable in VS Code for Web"
   type         = "list(string)"
   form_type    = "multi-select"
-  default      = jsonencode([for e in var.vscode_extensions : e.id if e.default])
+  default      = jsonencode([for e in local.vscode_extensions : e.id if e.default])
   mutable      = true
   order        = 100
 
   dynamic "option" {
-    for_each = var.vscode_extensions
+    for_each = local.vscode_extensions
     content {
       name  = option.value.name
       value = option.value.id

--- a/freeform/vscode-extensions.tf
+++ b/freeform/vscode-extensions.tf
@@ -1,0 +1,25 @@
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "golang.go", name = "Go", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
+}

--- a/freeform/vscode-extensions.tf
+++ b/freeform/vscode-extensions.tf
@@ -1,11 +1,10 @@
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
+locals {
+  # Deliberately a `locals`, not a `variable`: Coder pins the submitted value of any
+  # root-level `variable` block server-side the first time a template is pushed, and
+  # reuses that pinned value on later pushes instead of re-reading this file's list
+  # unless `--variable vscode_extensions=...` is passed again. `locals` are recomputed
+  # fresh on every plan, so there is nothing for Coder to pin.
+  vscode_extensions = [
     { id = "xdebug.php-debug", name = "PHP Debug", default = true },
     { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
     { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -183,6 +183,7 @@ RUN mkdir -p "$HOMEBREW_CACHE" && /home/linuxbrew/.linuxbrew/bin/brew install \
   claude-code \
   go \
   golangci-lint \
+  gopls \
   yq \
   zellij
 

--- a/shared/vscode-extensions.tf
+++ b/shared/vscode-extensions.tf
@@ -1,0 +1,25 @@
+variable "vscode_extensions" {
+  description = "List of VS Code extensions to offer in the workspace creation UI"
+  type = list(object({
+    id      = string
+    name    = string
+    default = bool
+  }))
+  default = [
+    { id = "xdebug.php-debug", name = "PHP Debug", default = true },
+    { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
+    { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },
+    { id = "esbenp.prettier-vscode", name = "Prettier", default = true },
+    { id = "sanderronde.phpstan-vscode", name = "PHPStan", default = true },
+    { id = "streetsidesoftware.code-spell-checker", name = "Code Spell Checker", default = true },
+    { id = "stylelint.vscode-stylelint", name = "Stylelint", default = true },
+    { id = "valeryanm.vscode-phpsab", name = "PHPSAB", default = true },
+    { id = "biati.ddev-manager", name = "DDEV Manager", default = true },
+    { id = "golang.go", name = "Go", default = true },
+    { id = "deque-systems.vscode-axe-linter", name = "Axe Linter", default = false },
+    { id = "andrewdavidblum.drupal-smart-snippets", name = "Drupal Smart Snippets", default = false },
+    { id = "redhat.vscode-yaml", name = "YAML", default = false },
+    { id = "sleistner.vscode-fileutils", name = "File Utils", default = false },
+    { id = "GitHub.vscode-pull-request-github", name = "GitHub Pull Requests", default = false },
+  ]
+}

--- a/shared/vscode-extensions.tf
+++ b/shared/vscode-extensions.tf
@@ -1,11 +1,10 @@
-variable "vscode_extensions" {
-  description = "List of VS Code extensions to offer in the workspace creation UI"
-  type = list(object({
-    id      = string
-    name    = string
-    default = bool
-  }))
-  default = [
+locals {
+  # Deliberately a `locals`, not a `variable`: Coder pins the submitted value of any
+  # root-level `variable` block server-side the first time a template is pushed, and
+  # reuses that pinned value on later pushes instead of re-reading this file's list
+  # unless `--variable vscode_extensions=...` is passed again. `locals` are recomputed
+  # fresh on every plan, so there is nothing for Coder to pin.
+  vscode_extensions = [
     { id = "xdebug.php-debug", name = "PHP Debug", default = true },
     { id = "bmewburn.vscode-intelephense-client", name = "Intelephense", default = true },
     { id = "dbaeumer.vscode-eslint", name = "ESLint", default = true },


### PR DESCRIPTION
## Summary
- Enable the `golang.go` VS Code extension by default in all three templates, and pre-install `gopls` via Homebrew (alongside the existing `go`/`golangci-lint`) so it's ready without the extension fetching it on first use.
- The `vscode_extensions` variable was byte-for-byte identical across `drupal-core`, `drupal-contrib`, and `freeform`. Extracted it into `shared/vscode-extensions.tf`, vendored into each template directory the same way `modules/claude-remote-control` already is — `coder templates push` and CI's `terraform validate`/`test` only ever see a single template directory, so a relative `../shared` reference wouldn't survive.
- Added a `sync-shared` Makefile target (wraps `sync-claude-module` + new `sync-vscode-extensions`) that `make validate`, `make test-templates`, and every `make push-template-*`/`push-all-templates` target now depend on, so vendoring happens automatically — no manual step.
- Documented the canonical-source-plus-vendored-copy pattern in `CLAUDE.md`, including why the vendored copies must stay committed (CI validates each template directory standalone, with no `make` step).

## Test plan
- [x] `terraform fmt -check -recursive`
- [x] `make validate` (init + validate for all three templates)
- [x] `make test-templates` (`terraform test` for all three templates, all passing)
- [ ] Push template(s) to a real Coder instance and confirm "Go" appears checked-by-default in the VS Code Extensions picker on workspace creation
- [ ] Open a `.go` file in VS Code for Web and confirm `gopls` is found without a prompt to auto-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
