### PR TITLE
fix(startup): quiet noisy Coder workspace startup logs

### DIFF
--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -434,11 +434,20 @@ EOF
     ddev config global --omit-containers=ddev-router --instrumentation-opt-in=false > /dev/null 2>&1 || true
     mkcert -install 2>/dev/null || true
 
+    # Pre-pull DDEV images (uses registry mirror if configured). Redirect --
+    # non-TTY docker pull progress prints a new line per layer per tick
+    # (often written to stderr), so unredirected this alone was 95% of a
+    # workspace's entire startup log.
     _t_images=$SECONDS
     echo "Pre-pulling DDEV images..."
-    ddev utility download-images || true
-    IMAGES_TIME=$((SECONDS - _t_images))
-    echo "  ddev utility download-images complete ($${IMAGES_TIME}s)"
+    if ddev utility download-images > /tmp/ddev-download-images.log 2>&1; then
+      IMAGES_TIME=$((SECONDS - _t_images))
+      echo "  ✓ ddev utility download-images complete ($${IMAGES_TIME}s)"
+    else
+      IMAGES_TIME=$((SECONDS - _t_images))
+      echo "  ⚠ ddev utility download-images failed after $${IMAGES_TIME}s (see /tmp/ddev-download-images.log)"
+      tail -20 /tmp/ddev-download-images.log || true
+    fi
 
     # ==========================================
     # DRUPAL CONTRIB AUTOMATIC SETUP
@@ -1057,6 +1066,9 @@ BASHPROFILE_WELCOME
     CODER_WORKSPACE_OWNER_NAME  = data.coder_workspace_owner.me.name
     CODER_WORKSPACE_OWNER_EMAIL = data.coder_workspace_owner.me.email
     HOME                        = "/home/coder"
+    # Silences Node's runtime deprecation warnings (e.g. url.parse()) that
+    # code-server prints once per extension during VS Code Web's install step.
+    NODE_NO_WARNINGS = "1"
   }
 
   metadata {

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -523,12 +523,20 @@ EOF
     # DDEV ships its own mkcert binary; this sets up the local CA trust
     mkcert -install 2>/dev/null || true
 
-    # Pre-pull DDEV images (uses registry mirror if configured)
+    # Pre-pull DDEV images (uses registry mirror if configured). Redirect --
+    # non-TTY docker pull progress prints a new line per layer per tick
+    # (often written to stderr), so unredirected this alone was 95% of a
+    # workspace's entire startup log.
     _t_images=$SECONDS
     echo "Pre-pulling DDEV images..."
-    ddev utility download-images || true
-    IMAGES_TIME=$((SECONDS - _t_images))
-    echo "  ddev utility download-images complete ($${IMAGES_TIME}s)"
+    if ddev utility download-images > /tmp/ddev-download-images.log 2>&1; then
+      IMAGES_TIME=$((SECONDS - _t_images))
+      echo "  ✓ ddev utility download-images complete ($${IMAGES_TIME}s)"
+    else
+      IMAGES_TIME=$((SECONDS - _t_images))
+      echo "  ⚠ ddev utility download-images failed after $${IMAGES_TIME}s (see /tmp/ddev-download-images.log)"
+      tail -20 /tmp/ddev-download-images.log || true
+    fi
 
     # ==========================================
     # DRUPAL CORE AUTOMATIC SETUP
@@ -1345,6 +1353,9 @@ BASHCOMP
     CODER_WORKSPACE_OWNER_EMAIL = data.coder_workspace_owner.me.email
     # Force HOME to /home/coder (Standard Home Strategy)
     HOME = "/home/coder"
+    # Silences Node's runtime deprecation warnings (e.g. url.parse()) that
+    # code-server prints once per extension during VS Code Web's install step.
+    NODE_NO_WARNINGS = "1"
   }
 
   metadata {

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -337,8 +337,18 @@ EOF
       echo "✓ DDEV host commands installed"
     fi
 
-    # Pre-pull DDEV images (uses registry mirror if configured)
-    ddev utility download-images || true
+    # Pre-pull DDEV images (uses registry mirror if configured). Redirect --
+    # non-TTY docker pull progress prints a new line per layer per tick
+    # (often written to stderr), so unredirected this alone was 95% of a
+    # workspace's entire startup log.
+    echo "Pre-pulling DDEV images..."
+    _t_images=$SECONDS
+    if ddev utility download-images > /tmp/ddev-download-images.log 2>&1; then
+      echo "✓ DDEV images ready ($((SECONDS - _t_images))s)"
+    else
+      echo "⚠ ddev utility download-images failed (see /tmp/ddev-download-images.log)"
+      tail -20 /tmp/ddev-download-images.log || true
+    fi
 
     # Ensure yq and linuxbrew are in PATH for this session
     export PATH="$PATH:/home/linuxbrew/.linuxbrew/bin"
@@ -427,6 +437,9 @@ BASHCOMP
     CODER_WORKSPACE_OWNER_EMAIL = data.coder_workspace_owner.me.email
     CODER_PROJECT_NAMES         = join(",", local.project_names)
     HOME                        = "/home/coder"
+    # Silences Node's runtime deprecation warnings (e.g. url.parse()) that
+    # code-server prints once per extension during VS Code Web's install step.
+    NODE_NO_WARNINGS = "1"
   }
 
   metadata {


### PR DESCRIPTION
## Summary
- `ddev utility download-images` ran unredirected in all three templates; since it's not a TTY, Docker's pull progress prints a new line per layer per tick instead of updating in place. In a real workspace this accounted for 4219 of 4426 startup log lines (95%), much of it at `[error]` level since Docker writes progress to stderr. Now redirected to `/tmp/ddev-download-images.log` with a one-line success/timing summary (or a log tail on failure).
- Added `NODE_NO_WARNINGS=1` to each `coder_agent` env block to silence Node's per-extension deprecation warnings during VS Code Web's extension install step.
- Verified against a real `ff2` workspace's build log — confirmed deployed and working.

## Test plan
- [x] `terraform fmt -recursive`
- [x] `make validate`
- [x] `make test-templates` (35 passed, 0 failed)
- [x] Verified reduced noise on a live workspace (ff2, staging-coder.ddev.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
