### PR TITLE
refactor(templates): DRY the two remaining byte-identical startup blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,7 @@ Key template variables (e.g. in `freeform/template.tf`):
 - This is an **infrastructure repository** managing Coder templates
 - Use feature branches for changes
 - **Never use the local `main` branch** — always `git fetch upstream` and base branches on `upstream/main`. Use `upstream/main` for comparisons (e.g. `git diff upstream/main...HEAD`), not local `main`.
+- **Never run `git push`, under any circumstances** — not to `main`, not to a feature branch, not to a fork. Commit locally and hand off to the user (or open a PR only if explicitly asked and only via a mechanism that doesn't require you to push, e.g. `gh pr create` from a branch the user has already pushed) — always let the user push.
 - Always use OpenSpec for architectural changes (see AGENTS.md)
 
 ### OpenSpec Integration

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,15 @@ sync-docker-daemon-module: ## Vendor modules/docker-daemon into each template di
 	done
 	@echo "Synced modules/docker-daemon into: $(TEMPLATES)"
 
+.PHONY: sync-bashrc-guard
+sync-bashrc-guard: ## Vendor shared/bashrc-symlink-guard.sh into each template dir (same reason as sync-vscode-extensions: push only bundles the given --directory)
+	@for t in $(TEMPLATES); do \
+		cp shared/bashrc-symlink-guard.sh $$t/bashrc-symlink-guard.sh; \
+	done
+	@echo "Synced shared/bashrc-symlink-guard.sh into: $(TEMPLATES)"
+
 .PHONY: sync-shared
-sync-shared: sync-claude-module sync-vscode-extensions sync-docker-daemon-module ## Vendor all shared Terraform assets (modules + vscode-extensions.tf) into each template dir
+sync-shared: sync-claude-module sync-vscode-extensions sync-docker-daemon-module sync-bashrc-guard ## Vendor all shared Terraform assets (modules + vscode-extensions.tf) into each template dir
 
 .PHONY: validate
 validate: sync-shared ## Validate all Terraform templates (requires terraform in PATH)

--- a/drupal-contrib/bashrc-symlink-guard.sh
+++ b/drupal-contrib/bashrc-symlink-guard.sh
@@ -1,0 +1,20 @@
+# If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
+# dotfiles repo checked out under $HOME), replace it with a real file
+# that sources the original target before the exports below get
+# appended. Every append/sed step further down writes straight through
+# symlinks, so a live symlink here would silently edit tracked files in
+# a developer's dotfiles repo instead of this workspace's local shell
+# config -- that happened once already.
+if [ -L "/home/coder/.bashrc" ]; then
+  _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
+  case "$_bashrc_target" in
+    /home/coder/*) ;; # resolves inside $HOME, safe to write through
+    *)
+      echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
+      rm -f "/home/coder/.bashrc"
+      if [ -n "$_bashrc_target" ]; then
+        echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
+      fi
+      ;;
+  esac
+fi

--- a/drupal-contrib/modules/docker-daemon/outputs.tf
+++ b/drupal-contrib/modules/docker-daemon/outputs.tf
@@ -1,6 +1,31 @@
 output "startup_script" {
-  description = "Bash snippet for the caller to append to its coder_agent startup_script, after registry-mirror configuration and before any command that needs Docker (ddev config global, image pre-pull, etc)."
+  description = "Bash snippet for the caller to append to its coder_agent startup_script, after locale/bashrc setup and before any command that needs Docker (ddev config global, image pre-pull, etc)."
   value       = <<-EOT
+
+    # Configure Docker daemon registry mirror.
+    # Priority: explicit Terraform variable, then auto-detect on Coder host:5000 if reachable.
+    REGISTRY_MIRROR="${var.docker_registry_mirror}"
+    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
+      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
+      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
+      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
+        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
+        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
+      else
+        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
+      fi
+    fi
+    if [ -n "$REGISTRY_MIRROR" ]; then
+      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
+      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
+      sudo mkdir -p /etc/docker
+      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "registry-mirrors": ["$REGISTRY_MIRROR"],
+  "insecure-registries": ["$MIRROR_HOST"]
+}
+EOF
+    fi
 
     # Start Docker Daemon (Sysbox). dockerd runs as a bare background
     # process here (no init system inside the container manages it), so

--- a/drupal-contrib/modules/docker-daemon/variables.tf
+++ b/drupal-contrib/modules/docker-daemon/variables.tf
@@ -2,3 +2,9 @@ variable "agent_id" {
   description = "ID of the coder_agent to attach the Docker daemon shutdown script to"
   type        = string
 }
+
+variable "docker_registry_mirror" {
+  description = "Optional Docker registry mirror URL override (e.g. http://your-host:5000). When empty, startup auto-detects a mirror at http://<coder-host>:5000 if reachable."
+  type        = string
+  default     = ""
+}

--- a/drupal-contrib/template.tf
+++ b/drupal-contrib/template.tf
@@ -290,26 +290,7 @@ resource "coder_agent" "main" {
     sudo chown coder:coder /home/coder
     sudo chown -R coder:coder /home/linuxbrew
 
-    # If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
-    # dotfiles repo checked out under $HOME), replace it with a real file
-    # that sources the original target before the exports below get
-    # appended. Every append/sed step further down writes straight through
-    # symlinks, so a live symlink here would silently edit tracked files in
-    # a developer's dotfiles repo instead of this workspace's local shell
-    # config -- that happened once already.
-    if [ -L "/home/coder/.bashrc" ]; then
-      _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
-      case "$_bashrc_target" in
-        /home/coder/*) ;; # resolves inside $HOME, safe to write through
-        *)
-          echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
-          rm -f "/home/coder/.bashrc"
-          if [ -n "$_bashrc_target" ]; then
-            echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
-          fi
-          ;;
-      esac
-    fi
+    ${file("${path.module}/bashrc-symlink-guard.sh")}
 
     if [ ! -f "/home/coder/.bashrc" ]; then
         echo "Initializing home directory..."
@@ -382,29 +363,6 @@ resource "coder_agent" "main" {
       echo '    [ -n "$branch" ] && echo " ($branch)"' >> ~/.bashrc
       echo '}' >> ~/.bashrc
       echo 'PS1='\''\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]$(git_prompt)\$ '\''' >> ~/.bashrc
-    fi
-
-    REGISTRY_MIRROR="${var.docker_registry_mirror}"
-    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
-      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
-      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
-      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
-        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
-        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
-      else
-        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
-      fi
-    fi
-    if [ -n "$REGISTRY_MIRROR" ]; then
-      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
-      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
-      sudo mkdir -p /etc/docker
-      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
-{
-  "registry-mirrors": ["$REGISTRY_MIRROR"],
-  "insecure-registries": ["$MIRROR_HOST"]
-}
-EOF
     fi
 
     ${module.docker_daemon.startup_script}
@@ -1141,8 +1099,9 @@ resource "coder_app" "mailpit" {
 }
 
 module "docker_daemon" {
-  source   = "./modules/docker-daemon"
-  agent_id = coder_agent.main.id
+  source                 = "./modules/docker-daemon"
+  agent_id               = coder_agent.main.id
+  docker_registry_mirror = var.docker_registry_mirror
 }
 
 resource "docker_container" "workspace" {

--- a/drupal-core/bashrc-symlink-guard.sh
+++ b/drupal-core/bashrc-symlink-guard.sh
@@ -1,0 +1,20 @@
+# If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
+# dotfiles repo checked out under $HOME), replace it with a real file
+# that sources the original target before the exports below get
+# appended. Every append/sed step further down writes straight through
+# symlinks, so a live symlink here would silently edit tracked files in
+# a developer's dotfiles repo instead of this workspace's local shell
+# config -- that happened once already.
+if [ -L "/home/coder/.bashrc" ]; then
+  _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
+  case "$_bashrc_target" in
+    /home/coder/*) ;; # resolves inside $HOME, safe to write through
+    *)
+      echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
+      rm -f "/home/coder/.bashrc"
+      if [ -n "$_bashrc_target" ]; then
+        echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
+      fi
+      ;;
+  esac
+fi

--- a/drupal-core/modules/docker-daemon/outputs.tf
+++ b/drupal-core/modules/docker-daemon/outputs.tf
@@ -1,6 +1,31 @@
 output "startup_script" {
-  description = "Bash snippet for the caller to append to its coder_agent startup_script, after registry-mirror configuration and before any command that needs Docker (ddev config global, image pre-pull, etc)."
+  description = "Bash snippet for the caller to append to its coder_agent startup_script, after locale/bashrc setup and before any command that needs Docker (ddev config global, image pre-pull, etc)."
   value       = <<-EOT
+
+    # Configure Docker daemon registry mirror.
+    # Priority: explicit Terraform variable, then auto-detect on Coder host:5000 if reachable.
+    REGISTRY_MIRROR="${var.docker_registry_mirror}"
+    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
+      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
+      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
+      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
+        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
+        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
+      else
+        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
+      fi
+    fi
+    if [ -n "$REGISTRY_MIRROR" ]; then
+      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
+      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
+      sudo mkdir -p /etc/docker
+      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "registry-mirrors": ["$REGISTRY_MIRROR"],
+  "insecure-registries": ["$MIRROR_HOST"]
+}
+EOF
+    fi
 
     # Start Docker Daemon (Sysbox). dockerd runs as a bare background
     # process here (no init system inside the container manages it), so

--- a/drupal-core/modules/docker-daemon/variables.tf
+++ b/drupal-core/modules/docker-daemon/variables.tf
@@ -2,3 +2,9 @@ variable "agent_id" {
   description = "ID of the coder_agent to attach the Docker daemon shutdown script to"
   type        = string
 }
+
+variable "docker_registry_mirror" {
+  description = "Optional Docker registry mirror URL override (e.g. http://your-host:5000). When empty, startup auto-detects a mirror at http://<coder-host>:5000 if reachable."
+  type        = string
+  default     = ""
+}

--- a/drupal-core/template.tf
+++ b/drupal-core/template.tf
@@ -332,26 +332,7 @@ resource "coder_agent" "main" {
     sudo chown coder:coder /home/coder
     sudo chown -R coder:coder /home/linuxbrew
 
-    # If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
-    # dotfiles repo checked out under $HOME), replace it with a real file
-    # that sources the original target before the exports below get
-    # appended. Every append/sed step further down writes straight through
-    # symlinks, so a live symlink here would silently edit tracked files in
-    # a developer's dotfiles repo instead of this workspace's local shell
-    # config -- that happened once already.
-    if [ -L "/home/coder/.bashrc" ]; then
-      _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
-      case "$_bashrc_target" in
-        /home/coder/*) ;; # resolves inside $HOME, safe to write through
-        *)
-          echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
-          rm -f "/home/coder/.bashrc"
-          if [ -n "$_bashrc_target" ]; then
-            echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
-          fi
-          ;;
-      esac
-    fi
+    ${file("${path.module}/bashrc-symlink-guard.sh")}
 
     # Copy defaults if empty (first run)
     if [ ! -f "/home/coder/.bashrc" ]; then
@@ -458,31 +439,6 @@ resource "coder_agent" "main" {
 
     # Node.js, TypeScript, and DDEV are now pre-installed in the Docker image (v3.0.30+)
 
-
-    # Configure Docker daemon registry mirror.
-    # Priority: explicit Terraform variable, then auto-detect on Coder host:5000 if reachable.
-    REGISTRY_MIRROR="${var.docker_registry_mirror}"
-    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
-      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
-      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
-      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
-        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
-        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
-      else
-        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
-      fi
-    fi
-    if [ -n "$REGISTRY_MIRROR" ]; then
-      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
-      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
-      sudo mkdir -p /etc/docker
-      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
-{
-  "registry-mirrors": ["$REGISTRY_MIRROR"],
-  "insecure-registries": ["$MIRROR_HOST"]
-}
-EOF
-    fi
 
     ${module.docker_daemon.startup_script}
 
@@ -1437,8 +1393,9 @@ resource "coder_app" "mailpit" {
 
 # Graceful DDEV shutdown when workspace stops
 module "docker_daemon" {
-  source   = "./modules/docker-daemon"
-  agent_id = coder_agent.main.id
+  source                 = "./modules/docker-daemon"
+  agent_id               = coder_agent.main.id
+  docker_registry_mirror = var.docker_registry_mirror
 }
 
 

--- a/freeform/bashrc-symlink-guard.sh
+++ b/freeform/bashrc-symlink-guard.sh
@@ -1,0 +1,20 @@
+# If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
+# dotfiles repo checked out under $HOME), replace it with a real file
+# that sources the original target before the exports below get
+# appended. Every append/sed step further down writes straight through
+# symlinks, so a live symlink here would silently edit tracked files in
+# a developer's dotfiles repo instead of this workspace's local shell
+# config -- that happened once already.
+if [ -L "/home/coder/.bashrc" ]; then
+  _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
+  case "$_bashrc_target" in
+    /home/coder/*) ;; # resolves inside $HOME, safe to write through
+    *)
+      echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
+      rm -f "/home/coder/.bashrc"
+      if [ -n "$_bashrc_target" ]; then
+        echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
+      fi
+      ;;
+  esac
+fi

--- a/freeform/modules/docker-daemon/outputs.tf
+++ b/freeform/modules/docker-daemon/outputs.tf
@@ -1,6 +1,31 @@
 output "startup_script" {
-  description = "Bash snippet for the caller to append to its coder_agent startup_script, after registry-mirror configuration and before any command that needs Docker (ddev config global, image pre-pull, etc)."
+  description = "Bash snippet for the caller to append to its coder_agent startup_script, after locale/bashrc setup and before any command that needs Docker (ddev config global, image pre-pull, etc)."
   value       = <<-EOT
+
+    # Configure Docker daemon registry mirror.
+    # Priority: explicit Terraform variable, then auto-detect on Coder host:5000 if reachable.
+    REGISTRY_MIRROR="${var.docker_registry_mirror}"
+    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
+      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
+      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
+      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
+        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
+        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
+      else
+        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
+      fi
+    fi
+    if [ -n "$REGISTRY_MIRROR" ]; then
+      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
+      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
+      sudo mkdir -p /etc/docker
+      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "registry-mirrors": ["$REGISTRY_MIRROR"],
+  "insecure-registries": ["$MIRROR_HOST"]
+}
+EOF
+    fi
 
     # Start Docker Daemon (Sysbox). dockerd runs as a bare background
     # process here (no init system inside the container manages it), so

--- a/freeform/modules/docker-daemon/variables.tf
+++ b/freeform/modules/docker-daemon/variables.tf
@@ -2,3 +2,9 @@ variable "agent_id" {
   description = "ID of the coder_agent to attach the Docker daemon shutdown script to"
   type        = string
 }
+
+variable "docker_registry_mirror" {
+  description = "Optional Docker registry mirror URL override (e.g. http://your-host:5000). When empty, startup auto-detects a mirror at http://<coder-host>:5000 if reachable."
+  type        = string
+  default     = ""
+}

--- a/freeform/template.tf
+++ b/freeform/template.tf
@@ -183,26 +183,7 @@ resource "coder_agent" "main" {
     sudo chown coder:coder /home/coder
     sudo chown -R coder:coder /home/linuxbrew
 
-    # If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
-    # dotfiles repo checked out under $HOME), replace it with a real file
-    # that sources the original target before the exports below get
-    # appended. Every append/sed step further down writes straight through
-    # symlinks, so a live symlink here would silently edit tracked files in
-    # a developer's dotfiles repo instead of this workspace's local shell
-    # config -- that happened once already.
-    if [ -L "/home/coder/.bashrc" ]; then
-      _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
-      case "$_bashrc_target" in
-        /home/coder/*) ;; # resolves inside $HOME, safe to write through
-        *)
-          echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
-          rm -f "/home/coder/.bashrc"
-          if [ -n "$_bashrc_target" ]; then
-            echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
-          fi
-          ;;
-      esac
-    fi
+    ${file("${path.module}/bashrc-symlink-guard.sh")}
 
     if [ ! -f "/home/coder/.bashrc" ]; then
         echo "Initializing home directory..."
@@ -278,31 +259,6 @@ resource "coder_agent" "main" {
         echo "export $_var=$_val" >> ~/.bashrc
       fi
     done
-
-    # Configure Docker daemon registry mirror.
-    # Priority: explicit Terraform variable, then auto-detect on Coder host:5000 if reachable.
-    REGISTRY_MIRROR="${var.docker_registry_mirror}"
-    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
-      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
-      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
-      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
-        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
-        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
-      else
-        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
-      fi
-    fi
-    if [ -n "$REGISTRY_MIRROR" ]; then
-      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
-      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
-      sudo mkdir -p /etc/docker
-      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
-{
-  "registry-mirrors": ["$REGISTRY_MIRROR"],
-  "insecure-registries": ["$MIRROR_HOST"]
-}
-EOF
-    fi
 
     ${module.docker_daemon.startup_script}
 
@@ -534,8 +490,9 @@ resource "coder_app" "adminer" {
 }
 
 module "docker_daemon" {
-  source   = "./modules/docker-daemon"
-  agent_id = coder_agent.main.id
+  source                 = "./modules/docker-daemon"
+  agent_id               = coder_agent.main.id
+  docker_registry_mirror = var.docker_registry_mirror
 }
 
 resource "docker_container" "workspace" {

--- a/modules/docker-daemon/outputs.tf
+++ b/modules/docker-daemon/outputs.tf
@@ -1,6 +1,31 @@
 output "startup_script" {
-  description = "Bash snippet for the caller to append to its coder_agent startup_script, after registry-mirror configuration and before any command that needs Docker (ddev config global, image pre-pull, etc)."
+  description = "Bash snippet for the caller to append to its coder_agent startup_script, after locale/bashrc setup and before any command that needs Docker (ddev config global, image pre-pull, etc)."
   value       = <<-EOT
+
+    # Configure Docker daemon registry mirror.
+    # Priority: explicit Terraform variable, then auto-detect on Coder host:5000 if reachable.
+    REGISTRY_MIRROR="${var.docker_registry_mirror}"
+    if [ -z "$REGISTRY_MIRROR" ] && [ -n "$CODER_AGENT_URL" ]; then
+      CODER_HOST=$(echo "$CODER_AGENT_URL" | sed -E 's#^https?://([^/:]+).*$#\1#')
+      CANDIDATE_MIRROR="http://$CODER_HOST:5000"
+      if [ -n "$CODER_HOST" ] && curl -fsS --max-time 2 "$CANDIDATE_MIRROR/v2/" > /dev/null 2>&1; then
+        REGISTRY_MIRROR="$CANDIDATE_MIRROR"
+        echo "Detected registry mirror on Coder host: $REGISTRY_MIRROR"
+      else
+        echo "No reachable registry mirror detected on Coder host; continuing without mirror"
+      fi
+    fi
+    if [ -n "$REGISTRY_MIRROR" ]; then
+      echo "Configuring Docker registry mirror: $REGISTRY_MIRROR"
+      MIRROR_HOST=$(echo "$REGISTRY_MIRROR" | sed 's|https\?://||')
+      sudo mkdir -p /etc/docker
+      sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "registry-mirrors": ["$REGISTRY_MIRROR"],
+  "insecure-registries": ["$MIRROR_HOST"]
+}
+EOF
+    fi
 
     # Start Docker Daemon (Sysbox). dockerd runs as a bare background
     # process here (no init system inside the container manages it), so

--- a/modules/docker-daemon/variables.tf
+++ b/modules/docker-daemon/variables.tf
@@ -2,3 +2,9 @@ variable "agent_id" {
   description = "ID of the coder_agent to attach the Docker daemon shutdown script to"
   type        = string
 }
+
+variable "docker_registry_mirror" {
+  description = "Optional Docker registry mirror URL override (e.g. http://your-host:5000). When empty, startup auto-detects a mirror at http://<coder-host>:5000 if reachable."
+  type        = string
+  default     = ""
+}

--- a/shared/bashrc-symlink-guard.sh
+++ b/shared/bashrc-symlink-guard.sh
@@ -1,0 +1,20 @@
+# If ~/.bashrc is already a symlink resolving outside $HOME (e.g. a
+# dotfiles repo checked out under $HOME), replace it with a real file
+# that sources the original target before the exports below get
+# appended. Every append/sed step further down writes straight through
+# symlinks, so a live symlink here would silently edit tracked files in
+# a developer's dotfiles repo instead of this workspace's local shell
+# config -- that happened once already.
+if [ -L "/home/coder/.bashrc" ]; then
+  _bashrc_target=$(readlink -f "/home/coder/.bashrc" 2>/dev/null || true)
+  case "$_bashrc_target" in
+    /home/coder/*) ;; # resolves inside $HOME, safe to write through
+    *)
+      echo "~/.bashrc is a symlink to $_bashrc_target (outside \$HOME); replacing with a local file that sources it"
+      rm -f "/home/coder/.bashrc"
+      if [ -n "$_bashrc_target" ]; then
+        echo "[ -r \"$_bashrc_target\" ] && source \"$_bashrc_target\"" > "/home/coder/.bashrc"
+      fi
+      ;;
+  esac
+fi


### PR DESCRIPTION
## Summary
- Follow-up to #194: two more sections of the per-template `startup_script` were duplicated **byte-for-byte identically** across all three templates (confirmed via diff, unlike other similar-looking sections that have already drifted in small ways) — the Docker registry-mirror configuration and the `~/.bashrc` symlink-safety guard.
- Registry-mirror config now lives in `modules/docker-daemon` (it configures `/etc/docker/daemon.json` right before the daemon starts, so it belongs with the rest of the Docker lifecycle logic already there); the module gained a `docker_registry_mirror` input variable that each template passes through from its own variable of the same name.
- The bashrc-symlink guard needs no variables and creates no resource, so it's vendored as a plain `shared/bashrc-symlink-guard.sh` (same vendoring technique as `shared/vscode-extensions.tf`) and pulled into each `startup_script` via `file("${path.module}/bashrc-symlink-guard.sh")`.
- Net: 16 files touched, -144/+228 (the extra insertions are the vendored per-template copies + module scaffolding; the net duplication removed from the three `template.tf` files themselves is ~140 lines).

Depends on #194 (this branch is stacked on `20260806_docker_survival` since it extends the `docker-daemon` module that PR introduces) — will need a rebase once that merges, but the two PRs don't touch overlapping lines so there's no actual conflict.

## Test plan
- [x] `terraform fmt -recursive` clean
- [x] `make validate` — all three templates valid
- [x] `make test-templates` — all Terraform mock tests pass
- [x] Pushed to staging-coder.ddev.com and updated workspace `d12-1`: registry mirror still auto-detected/configured (`Detected registry mirror on Coder host: ...`), Docker daemon started cleanly, all DDEV containers came up healthy
